### PR TITLE
Adding a SciGraph adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,7 @@ release: cleandist
 nb:
 	PYTHONPATH=.. jupyter notebook
 
+# Hack: generate marshmallow schema from flaskrest serializers
+# used to make assoc_schema.py
 mm:
 	./bin/flask2marshmallow.pl ../biolink-api/biolink/datamodel/serializers.py 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<[![Build Status](https://travis-ci.org/biolink/ontobio.svg?branch=master)](https://travis-ci.org/biolink/ontobio)
 [![DOI](https://zenodo.org/badge/13996/biolink/ontobio.svg)](https://zenodo.org/badge/latestdoi/13996/biolink/ontobio)
 [![PyPI](https://img.shields.io/pypi/v/ontobio.svg)](https://pypi.python.org/pypi/ontobio)
 

--- a/bin/ogr.py
+++ b/bin/ogr.py
@@ -84,7 +84,7 @@ def main():
         logging.info("Query for level: {}".format(args.level))
         qids = qids + ont.get_level(args.level, relations=args.properties, prefix=args.prefix)
 
-    if args.insubset is not None:
+    if args.insubset is not None and args.insubset != "":
         disjs = args.insubset.split("|")
         dset = set()
         for i in disjs:
@@ -116,8 +116,10 @@ def main():
     nodes = ont.traverse_nodes(qids, up=dirn.find("u") > -1, down=dirn.find("d") > -1,
                                relations=args.properties)
 
-    g = ont.get_filtered_graph(relations=args.properties)
-    show_subgraph(ont, nodes, qids, args)
+    # deprecated
+    #g = ont.get_filtered_graph(relations=args.properties)
+    subont = ont.subontology(nodes, relations=args.properties)
+    show_subgraph(subont, qids, args)
 
 
 def cmd_cycles(handle, args):
@@ -132,7 +134,7 @@ def cmd_search(handle, args):
         for r in results:
             print(r)
 
-def show_subgraph(ont, nodes, query_ids, args):
+def show_subgraph(ont, query_ids, args):
     """
     Writes or displays graph
     """
@@ -142,8 +144,9 @@ def show_subgraph(ont, nodes, query_ids, args):
     w = GraphRenderer.create(args.to)
     if args.outfile is not None:
         w.outfile = args.outfile
-    logging.info("Writing subgraph for {}, |nodes|={}".format(ont,len(nodes)))
-    w.write_subgraph(ont, nodes, query_ids=query_ids, container_predicates=args.container_properties)
+    w.write(ont, query_ids=query_ids, container_predicates=args.container_properties)
+    #logging.info("Writing subgraph for {}, |nodes|={}".format(ont,len(nodes)))
+    #w.write_subgraph(ont, nodes, query_ids=query_ids, container_predicates=args.container_properties)
             
 def resolve_ids(ont, ids, args):
     r_ids = []

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -17,7 +17,7 @@ scigraph_ontology:
   url: "https://scigraph-ontology.monarchinitiative.org/scigraph/"
   timeout: 2
 scigraph_data:
-  url: "https://scigraph-ontology.monarchinitiative.org/scigraph/"
+  url: "https://scigraph-data.monarchinitiative.org/scigraph/"
   timeout: 2
 use_amigo_for:
   - function

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -74,6 +74,34 @@ Code example, using an :class:`OntologyFactory`
     from ontobio.ontol_factory import OntologyFactory
     ont = OntologyFactory().create("cl")
 
+Remote SciGraph ontology access
+-------------------------------
+
+.. warning ::
+
+    Experimental
+
+Command line example:
+
+::
+
+   ogr.py -r scigraph:ontology
+
+Code example, using an :class:`OntologyFactory`
+
+.. code-block:: python
+
+    from ontobio.ontol_factory import OntologyFactory
+    ont = OntologyFactory().create("scigraph:ontology")
+
+
+.. warning ::
+
+    Since SciGraph contains multiple graphs interwoven together, care
+    must be taken on queries that don't use relationship types, as
+    ancestor/descendant lists may be large
+    
+    
 Local GAF or GPAD association files
 -----------------------------------
 

--- a/ontobio/io/ontol_renderers.py
+++ b/ontobio/io/ontol_renderers.py
@@ -60,14 +60,14 @@ class GraphRenderer():
         """
         Render a `ontology` object after inducing a subgraph
         """
-        subont = ontol.subontology(nodes)
+        subont = ontol.subontology(nodes, **args)
         return self.render(subont, **args)
     
     def write_subgraph(self, ontol, nodes, **args):
         """
         Write a `ontology` object after inducing a subgraph
         """
-        subont = ontol.subontology(nodes)
+        subont = ontol.subontology(nodes, **args)
         self.write(subont, **args)
 
     def render_relation(self, r, **args):

--- a/ontobio/ontol.py
+++ b/ontobio/ontol.py
@@ -639,6 +639,18 @@ class Ontology():
         if include_label:
             syns.append(Synonym(nid, val=self.label(nid), pred='label'))
         return syns
+    
+    def add_synonym(self, syn):
+        """
+        Adds a synonym for a node
+        """
+        n = self.node(syn.class_id)
+        if 'meta' not in n:
+            n['meta'] = {}
+        meta = n['meta']
+        if 'synonyms' not in meta:
+            meta['synonyms'] = []
+        meta['synonyms'].append({'val': syn.val,'pred': syn.pred})
 
     def all_synonyms(self, include_label=False):
         """

--- a/ontobio/ontol.py
+++ b/ontobio/ontol.py
@@ -114,7 +114,6 @@ class Ontology():
             for (o,s,m) in xg.edges(data=True):
                 g.add_edge(o,s,attr_dict=m)
             
-        
     def subgraph(self, nodes=[]):
         """
         Return an induced subgraph
@@ -139,12 +138,14 @@ class Ontology():
             list of relation IDs to include in subontology. If None, all are used
 
         """
-        g = self.get_graph()
+        g = None
         if nodes is not None:
-            g = g.subgraph(nodes)
+            g = self.subgraph(nodes)
+        else:
+            g = self.get_graph()            
         if minimal:
             from ontobio.slimmer import get_minimal_subgraph
-            g = get_minimal_subgraph(self.get_graph(), nodes)
+            g = get_minimal_subgraph(g, nodes)
             
         ont = Ontology(graph=g) # TODO - add metadata
         if relations is not None:

--- a/ontobio/ontol_factory.py
+++ b/ontobio/ontol_factory.py
@@ -86,7 +86,8 @@ def create_ontology(handle=None, **args):
         ont = onts.pop()
         ont.merge(onts)
         return ont
-    
+
+    # TODO: consider replacing with plugin architecture
     if handle.find(".") > 0 and os.path.isfile(handle):
         logging.info("Fetching obograph-json file from filesystem")
         ont = translate_file_to_ontology(handle, **args)
@@ -108,6 +109,10 @@ def create_ontology(handle=None, **args):
         from ontobio.sparql.wikidata_ontology import EagerWikidataOntology
         logging.info("Fetching from Wikidata")
         ont = EagerWikidataOntology(handle=handle)
+    elif handle.startswith("scigraph:"):
+        from ontobio.neo.scigraph_ontology import RemoteScigraphOntology
+        logging.info("Fetching from SciGraph")
+        ont = RemoteScigraphOntology(handle=handle)
     elif handle.startswith("http:"):
         logging.info("Fetching from Web PURL: "+handle)
         encoded = hashlib.sha256(handle.encode()).hexdigest()

--- a/tests/test_remote_scigraph.py
+++ b/tests/test_remote_scigraph.py
@@ -1,0 +1,111 @@
+from ontobio.ontol_factory import OntologyFactory
+import logging
+
+HAS_PART = 'BFO:0000051'
+PART_OF = 'BFO:0000050'
+
+QUALITY = 'PATO:0000001'
+PLOIDY = 'PATO:0001374'
+EUPLOID = 'PATO:0001393'
+SHAPE = 'PATO:0000052'
+Y_SHAPED = 'PATO:0001201'
+PENTAPLOID = 'PATO:0001383'
+SWOLLEN = 'PATO:0001851'
+DILATED = 'PATO:0001571'
+INCREASED_SIZE = 'PATO:0000586'
+PROTRUDING = 'PATO:0001598'
+MORPHOLOGY = 'PATO:0000051'
+ABSENT = 'PATO:0000462'
+CONICAL = 'PATO:0002021'
+
+def test_remote_sparql():
+    """
+    Load ontology from remote SPARQL endpoint
+    """
+    factory = OntologyFactory()
+    print("Creating ont")
+    ont = factory.create('scigraph:ontology')
+
+    ploidy = ont.node(PLOIDY)
+    print("PLOIDY: {}".format(ploidy))
+    assert ont.label(PLOIDY) == 'ploidy'
+
+    # exact match
+    search_results = ont.search('shape')
+    print("SEARCH (exact): {}".format(search_results))
+    assert [SHAPE] == search_results
+
+    # implicit regexp
+    search_results = ont.search('%lantern%')
+    print("SEARCH (re, implicit): {}".format(search_results))
+    assert 'UBERON:0008253' in search_results
+    
+    # syns
+    syn = 'cone-shaped'
+    search_results = ont.search(syn, synonyms=False)
+    print("SEARCH (no syns): {}".format(search_results))
+    assert [] == search_results
+    #search_results = ont.search(syn, synonyms=True)
+    #print("SEARCH (with syns): {}".format(search_results))
+    #assert [CONICAL] == search_results
+    
+
+    ancs = ont.ancestors(PLOIDY, relations=['subClassOf'])
+    print("ANCS ploidy (subClassOf): {}".format(ancs))
+    assert QUALITY in ancs
+    assert PENTAPLOID not in ancs
+
+    # this is a non-use case
+    ancs = ont.ancestors(SWOLLEN, relations=[HAS_PART])
+    print("ANCS swollen (has_part): {}".format(ancs))
+    assert INCREASED_SIZE in ancs
+    assert PROTRUDING in ancs
+    assert len(ancs) == 2
+
+    ancs = ont.ancestors(SWOLLEN, relations=['subClassOf'], reflexive=False)
+    print("ANCS swollen (has_part): {}".format(ancs))
+    assert MORPHOLOGY in ancs
+    assert QUALITY in ancs
+    assert PROTRUDING not in ancs
+    
+    #decs = ont.descendants(PLOIDY)
+    #print("DECS ploidy (all): {}".format(decs))
+    #assert QUALITY not in decs
+    #assert EUPLOID in decs
+    #assert PENTAPLOID in decs
+
+    # this is a non-use case
+    ancs = ont.descendants(INCREASED_SIZE, relations=[HAS_PART])
+    print("ANCS increased size (has part): {}".format(ancs))
+    assert SWOLLEN in ancs
+    assert len(ancs) == 1
+
+    #subsets = ont.subsets()
+    #print("SUBSETS: {}".format(subsets))
+
+    #slim = ont.extract_subset('absent_slim')
+    #print("SLIM: {}".format(slim))
+    #assert ABSENT in slim
+    #assert QUALITY not in slim
+
+def test_subontology():
+    """
+    subontology
+    """
+    factory = OntologyFactory()
+    print("Creating ont")
+    ont = factory.create('scigraph:ontology')
+    print("ONT NODES: {}".format(ont.nodes()))
+    subont = ont.subontology(relations=['subClassOf'])
+    PERM = 'GO:1990578'
+    print("NODES: {}".format(subont.nodes()))
+    ancs = subont.ancestors(PERM, reflexive=True)
+    print(str(ancs))
+    for a in ancs:
+        print(" ANC: {} '{}'".format(a,subont.label(a)))
+    assert len(ancs) > 0
+    from ontobio.io.ontol_renderers import GraphRenderer
+    w = GraphRenderer.create('tree')
+    w.write_subgraph(ont, ancs)
+
+    


### PR DESCRIPTION
This PR adds an adapter for OB to transparently query a remote scigraph instance as if it were a local ontology.

For more background see: http://ontobio.readthedocs.io/en/latest/inputs.html