### PR TITLE
more robust column values decomposition

### DIFF
--- a/ontobio/io/entityparser.py
+++ b/ontobio/io/entityparser.py
@@ -97,7 +97,7 @@ class GpiParser(EntityParser):
         vals = line.split("\t")
 
         if len(vals) < 7:
-            self.report.error(line, type, obj)
+            self.report.error(line, Report.WRONG_NUMBER_OF_COLUMNS, "")
             return line, []
 
         if len(vals) < 10 and len(vals) >= 7:

--- a/ontobio/io/entityparser.py
+++ b/ontobio/io/entityparser.py
@@ -95,7 +95,10 @@ class GpiParser(EntityParser):
 
         """
         vals = line.split("\t")
-        print(vals)
+
+        if len(vals) < 7:
+            self.report.error(line, type, obj)
+            return line, []
 
         if len(vals) < 10 and len(vals) >= 7:
             missing_columns = 10 - len(vals)

--- a/ontobio/io/entityparser.py
+++ b/ontobio/io/entityparser.py
@@ -95,16 +95,25 @@ class GpiParser(EntityParser):
 
         """
         vals = line.split("\t")
-        [db,
-         db_object_id,
-         db_object_symbol,
-         db_object_name,
-         db_object_synonym,
-         db_object_type,
-         taxon,
-         parent_object_id,
-         xrefs,
-         properties] = vals
+        print(vals)
+
+        if len(vals) < 10 and len(vals) >= 7:
+            missing_columns = 10 - len(vals)
+            vals += ["" for i in range(missing_columns)]
+
+        [
+            db,
+            db_object_id,
+            db_object_symbol,
+            db_object_name,
+            db_object_synonym,
+            db_object_type,
+            taxon,
+            parent_object_id,
+            xrefs,
+            properties
+        ] = vals
+
 
         ## --
         ## db + db_object_id. CARD=1

--- a/tests/test_gpiparser.py
+++ b/tests/test_gpiparser.py
@@ -4,7 +4,7 @@ from ontobio.ontol_factory import OntologyFactory
 
 ONT = "tests/resources/go-truncated-pombase.json"
 GPI = "tests/resources/truncated-mgi.gpi"
-    
+
 def test_parse_gpi():
     ont = OntologyFactory().create(ONT)
     p = GpiParser()
@@ -21,11 +21,9 @@ def test_parse_gpi():
 
     r2 = results[-1]
     assert r2['parents'] == ['MGI:109279']
-    
-    
+
+
     for m in p.report.messages:
         print("MESSAGE: {}".format(m))
     assert len(p.report.messages) == 0
     print(p.report.to_markdown())
-    
-    

--- a/tests/test_gpiparser.py
+++ b/tests/test_gpiparser.py
@@ -27,3 +27,9 @@ def test_parse_gpi():
         print("MESSAGE: {}".format(m))
     assert len(p.report.messages) == 0
     print(p.report.to_markdown())
+
+def test_gpi_skips_lines_with_incorrect_collumns():
+    parser = GpiParser()
+    parsed = parser.parse_line("hello\tworld\tfoo\tbar")
+
+    assert parsed[1] == []


### PR DESCRIPTION
This fixes the immediate zfin issues. Fills in missing columns with the empty string. If it's more than 3 missing it'll still fail. 

Zfin now spits out line errors, rather than just crashing immediately. 