### PR TITLE
uses assocwriter to write parsed validated gaf. parser replaces space s in relationship expressions with underscore

### DIFF
--- a/bin/ontobio-parse-assocs.py
+++ b/bin/ontobio-parse-assocs.py
@@ -147,7 +147,7 @@ def main():
     func(ont, args.file, outfh, p, args)
     if filtered_evidence_file:
         filtered_evidence_file.close()
-        
+
     if outfh is not None:
         outfh.close()
     if args.messagefile is not None:
@@ -161,7 +161,12 @@ def filter_assocs(ont, file, outfile, p, args):
     p.generate_associations(open(file, "r"), outfile)
 
 def validate_assocs(ont, file, outfile, p, args):
-    p.generate_associations(open(file, "r"), outfile)
+    gafwriter = GafWriter(file=outfile)
+
+    with open(file) as gafsource:
+        associations = p.association_generator(file=gafsource)
+        for assoc in associations:
+            gafwriter.write_assoc(assoc)
 
 def validate_entity(ont, file, outfile, p, args):
     p.parse(open(file, "r"), outfile)
@@ -181,7 +186,7 @@ def write_assocs(assocs, outfile, args):
         raise ValueError("Not supported: {}".format(fmt))
     w.file = outfile
     w.write(assocs)
-    
+
 def map2slim(ont, file, outfile, p, args):
     logging.info("Mapping to {}".format(args.subset))
     assocs = p.map_to_subset(open(file, "r"),

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -541,9 +541,8 @@ class AssocParser(object):
             self.report.error(line, Report.EXTENSION_SYNTAX_ERROR, x, msg="does not follow REL(ID) syntax")
             return None
         (p,v) = tuples[0]
-        v = v.replace(" ", "_")
 
-        if self._validate_id(v,line,EXTENSION):
+        if self._validate_id(v, line,EXTENSION):
             return {
                 'property':p,
                 'filler':v

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -541,13 +541,15 @@ class AssocParser(object):
             self.report.error(line, Report.EXTENSION_SYNTAX_ERROR, x, msg="does not follow REL(ID) syntax")
             return None
         (p,v) = tuples[0]
+        v = v.replace(" ", "_")
+
         if self._validate_id(v,line,EXTENSION):
             return {
                 'property':p,
                 'filler':v
             }
         else:
-            self.report.error(line, Report.EXTENSION_SYNTAX_ERROR, x, msg="ID not valid")            
+            self.report.error(line, Report.EXTENSION_SYNTAX_ERROR, x, msg="ID not valid")
             return None
 
 # TODO consider making an Association its own class too to give it a little more

--- a/ontobio/io/assocwriter.py
+++ b/ontobio/io/assocwriter.py
@@ -22,7 +22,7 @@ class AssocWriter():
     """
     def _split_prefix(self, ref):
         id = ref['id']
-        [prefix, local_id] = id.split(':')
+        [prefix, local_id] = id.split(':', maxsplit=1)
         return prefix, local_id
 
     def _write_row(self, vals):
@@ -35,7 +35,7 @@ class AssocWriter():
     def _extension_expression(self, assoc):
         xs = []
         for e in assoc.get('object_extensions',[]):
-            xs.append('{}({})'.format(e['property'],e['filler']))
+            xs.append('{}({})'.format(e['property'], e['filler']))
         return ",".join(xs)
 
     def write_assoc(self, assoc):
@@ -43,7 +43,7 @@ class AssocWriter():
         Write a single association to a line in the output file
         """
         pass  ## Implemented in subclasses
-    
+
     def write(self, assocs, meta=None):
         """
         Write a complete set of associations to a file
@@ -58,7 +58,7 @@ class AssocWriter():
         """
         for a in assocs:
             self.write_assoc(a)
-        
+
 class GpadWriter(AssocWriter):
     """
     Writes Associations in GPAD format
@@ -71,7 +71,7 @@ class GpadWriter(AssocWriter):
         Write a single association to a line in the output file
         """
         subj = assoc['subject']
-        
+
         db, db_object_id = self._split_prefix(subj)
 
         rel = assoc['relation']
@@ -91,7 +91,7 @@ class GpadWriter(AssocWriter):
 
         annotation_properties = '' # TODO
         interacting_taxon_id = '' ## TODO
-        
+
         vals = [db,
                 db_object_id,
                 qualifier,
@@ -106,7 +106,7 @@ class GpadWriter(AssocWriter):
                 annotation_properties]
 
         self._write_row(vals)
-    
+
 class GafWriter(AssocWriter):
     """
     Writes Associations in GAF format. Not yet implemented
@@ -119,7 +119,7 @@ class GafWriter(AssocWriter):
         Write a single association to a line in the output file
         """
         subj = assoc['subject']
-        
+
         db, db_object_id = self._split_prefix(subj)
 
         rel = assoc['relation']
@@ -145,7 +145,7 @@ class GafWriter(AssocWriter):
         taxon = None
         if 'taxon' in subj:
             taxon = subj['taxon']['id']
-            
+
         vals = [db,
                 db_object_id,
                 subj.get('label'),
@@ -165,4 +165,3 @@ class GafWriter(AssocWriter):
                 gene_product_isoform]
 
         self._write_row(vals)
-


### PR DESCRIPTION
Ontobio just passes on spaces in the offending space in ids in relation expressions. This fixes this by simply replacing spaces with underscores. This won't create a correct id, as the space in the id is ultimately from upsteam. But this allows ontobio parsed gafs to then be turned into ttl at all, and ingested by blazegraph. We can correct the underscores with subsequent blazegraph loads (with the corrected ids), or with sparql queries later. 