### PR TITLE
WB for WormBase is too agressive as it changes the gene ID too

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -121,7 +121,6 @@ M=GolrFields()
 PREFIX_NORMALIZATION_MAP = {
     'MGI:MGI' : 'MGI',
     'FB' : 'FlyBase',
-    'WB' : 'WormBase'
 }
 
 def flip(d, x, y):


### PR DESCRIPTION
The fix in PREFIX_NORMALIZATION_MAP actually didn't help since WormBase is needed for the homolog search, but WB for the GO annotations