### PR TITLE
gafwriter spits out the gaf version, and filtered evidence should cop…

### DIFF
--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -147,9 +147,8 @@ class Report():
             self.skipped.append(result.parsed_line)
         else:
             self.add_associations(result.associations)
-            write_to_file(output_file, result.parsed_line)
             if result.evidence_used not in evidence_to_filter:
-                write_to_file(evidence_filtered_file, result.parsed_line)
+                write_to_file(evidence_filtered_file, result.parsed_line + "\n")
 
     def short_summary(self):
         return "Parsed {} assocs from {} lines. Skipped: {}".format(self.n_assocs, self.n_lines, len(self.skipped))

--- a/ontobio/io/assocwriter.py
+++ b/ontobio/io/assocwriter.py
@@ -113,6 +113,8 @@ class GafWriter(AssocWriter):
     """
     def __init__(self, file=None):
         self.file = file
+        if file != None: # This should never be none. Let's make file requiered here.
+            file.write("!gaf-version: 2.1\n")
 
     def write_assoc(self, assoc):
         """


### PR DESCRIPTION
…y the headers from the source

I tested this locally and it appears to be passing through the header in both no_iea and standard gafs.