### PR TITLE
throws out lines with bad chars in ids

### DIFF
--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -469,7 +469,7 @@ class AssocParser(object):
             self.report.error(line, Report.INVALID_ID, id, "must be CURIE/prefixed ID")
             return False
 
-        if re.search("[^_\-0-9a-zA-Z]", id.split(":")[1]):
+        if re.search("[^\.:_\-0-9a-zA-Z]", id.split(":")[1]):
             self.report.error(line, Report.INVALID_ID, id, "contains non letter, non number character")
             return False
 

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -469,6 +469,10 @@ class AssocParser(object):
             self.report.error(line, Report.INVALID_ID, id, "must be CURIE/prefixed ID")
             return False
 
+        if re.search("[^_\-0-9a-zA-Z]", id.split(":")[1]):
+            self.report.error(line, Report.INVALID_ID, id, "contains non letter, non number character")
+            return False
+
         idspace = self._get_id_prefix(id)
         # ensure that the ID space of the annotation class (e.g. GO)
         # conforms to what is expected

--- a/ontobio/rdfgen/assoc_rdfgen.py
+++ b/ontobio/rdfgen/assoc_rdfgen.py
@@ -14,6 +14,7 @@ from rdflib.namespace import OWL
 import rdflib
 import logging
 import uuid
+import re
 
 ro = OboRO()
 evt = Evidence()
@@ -79,6 +80,7 @@ class RdfTransform(object):
         self.uribase = writer.base
         self.ro = None
         self.ecomap.mappings()
+        self.bad_chars_regex = re.compile("[^:_\-0-9a-zA-Z]")
 
     def blanknode(self):
         return BNode()
@@ -89,6 +91,7 @@ class RdfTransform(object):
             return self.uri(id['id'])
         logging.info("Expand: {}".format(id))
 
+        id = self.bad_chars_regex.sub("_", id)
         uri = curie_util.expand_uri(id, cmaps=[prefix_context])
         if uri != id:
             # If URI is different, then that means we found an curie expansion, and we should add the prefix

--- a/ontobio/rdfgen/assoc_rdfgen.py
+++ b/ontobio/rdfgen/assoc_rdfgen.py
@@ -80,7 +80,7 @@ class RdfTransform(object):
         self.uribase = writer.base
         self.ro = None
         self.ecomap.mappings()
-        self.bad_chars_regex = re.compile("[^:_\-0-9a-zA-Z]")
+        self.bad_chars_regex = re.compile("[^\.:_\-0-9a-zA-Z]")
 
     def blanknode(self):
         return BNode()


### PR DESCRIPTION
Temporary fix for bad IDs in GAFs. 

In messages, @cmungall  suggested we repair on the fly, but looking at the code, that's not how the strategy works at the moment. In order to get the run to work, this will stick with the throw-out-bad-line strat until we work with a different strategy. 

We can also make the rdfgen process a little more resilient to bad ids. If we want that in this, we can make that happen. But as it stands, this fixes the rdfgen issues.