### PR TITLE
Ability to fetch annotation extensions in GOlr query.

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -100,6 +100,7 @@ class GolrFields:
     EVIDENCE_OBJECT_LABEL='evidence_object_label'
     _VERSION_='_version_'
     SUBJECT_GENE_CLOSURE_LABEL_SEARCHABLE='subject_gene_closure_label_searchable'
+    ANNOTATION_EXTENSION_JSON="annotation_extension_json"
 
     RELATION='relation'
     RELATION_LABEL='relation_label'
@@ -1144,6 +1145,9 @@ class GolrAssociationQuery(GolrAbstractQuery):
         # solr does not allow nested objects, so evidence graph is json-encoded
         if M.EVIDENCE_GRAPH in d:
             assoc[M.EVIDENCE_GRAPH] = json.loads(d[M.EVIDENCE_GRAPH])
+
+        if M.ANNOTATION_EXTENSION_JSON in d:
+            assoc['annotation_extensions'] = [json.loads(ext) for ext in d[M.ANNOTATION_EXTENSION_JSON]]
         return assoc
 
     def translate_docs(self, ds, **kwargs):


### PR DESCRIPTION
This will allow us to see annotations having the infamous column 16 (extension) field filled in. Using this to help find PomBase annotations that may be good for potential Noctua models.