### PR TITLE
use AmiGO schema-specific evidence fields in Solr query

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -104,6 +104,20 @@ class GolrFields:
     RELATION='relation'
     RELATION_LABEL='relation_label'
 
+    # This is a temporary fix until
+    # https://github.com/biolink/ontobio/issues/126 is resolved.
+
+    # AmiGO specific evidence fields
+    AMIGO_EVIDENCE_FIELDS = [
+        'evidence',
+        'evidence_label',
+        'evidence_type',
+        'evidence_closure',
+        'evidence_closure_label',
+        'evidence_subset_closure',
+        'evidence_subset_closure_label'
+    ]
+
     # golr convention: for any entity FOO, the id is denoted 'foo'
     # and the label FOO_label
     def label_field(self, f):
@@ -824,6 +838,10 @@ class GolrAssociationQuery(GolrAbstractQuery):
 
         facet_fields = [ map_field(fn, self.field_mapping) for fn in facet_fields ]
 
+        if self._use_amigo_schema:
+            if len([x for x in select_fields if x in M.AMIGO_EVIDENCE_FIELDS]) == 0:
+                select_fields += M.AMIGO_EVIDENCE_FIELDS
+
         ## true if iterate in windows of max_size until all results found
         iterate=self.iterate
 
@@ -1140,7 +1158,12 @@ class GolrAssociationQuery(GolrAbstractQuery):
         if M.EVIDENCE_OBJECT in d:
             assoc['evidence'] = d[M.EVIDENCE_OBJECT]
             assoc['types'] = [t for t in d[M.EVIDENCE_OBJECT] if t.startswith('ECO:')]
-            
+
+        if self._use_amigo_schema:
+            for f in M.AMIGO_EVIDENCE_FIELDS:
+                if f in d:
+                    assoc[f] = d[f]
+
         # solr does not allow nested objects, so evidence graph is json-encoded
         if M.EVIDENCE_GRAPH in d:
             assoc[M.EVIDENCE_GRAPH] = json.loads(d[M.EVIDENCE_GRAPH])

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -112,10 +112,14 @@ class GolrFields:
         'evidence',
         'evidence_label',
         'evidence_type',
+        'evidence_type_label',
+        'evidence_with',
         'evidence_closure',
         'evidence_closure_label',
         'evidence_subset_closure',
-        'evidence_subset_closure_label'
+        'evidence_subset_closure_label',
+        'evidence_type_closure',
+        'evidence_type_closure_label'
     ]
 
     # golr convention: for any entity FOO, the id is denoted 'foo'


### PR DESCRIPTION
This PR aims at using AmiGO schema-specific evidence fields in Solr query.

A good example is when there is a call to the biolink-api endpoint `bioentityset/slimmer/function`.

```
https://api.monarchinitiative.org/api/bioentityset/slimmer/function?&slim=GO:0003824&slim=GO:0004872&slim=GO:0005102&slim=GO:0005215&slim=GO:0005198&slim=GO:0008092&slim=GO:0003677&slim=GO:0003723&slim=GO:0001071&slim=GO:0036094&slim=GO:0046872&slim=GO:0030246&slim=GO:0003674&slim=GO:0008283&slim=GO:0071840&slim=GO:0051179&slim=GO:0032502&slim=GO:0000003&slim=GO:0002376&slim=GO:0050877&slim=GO:0050896&slim=GO:0023052&slim=GO:0010467&slim=GO:0019538&slim=GO:0006259&slim=GO:0044281&slim=GO:0050789&slim=GO:0042592&slim=GO:0007610&slim=GO:0008150&slim=GO:0005576&slim=GO:0005737&slim=GO:0005856&slim=GO:0005739&slim=GO:0005634&slim=GO:0005694&slim=GO:0016020&slim=GO:0031982&slim=GO:0071944&slim=GO:0030054&slim=GO:0042995&slim=GO:0032991&slim=GO:0045202&slim=GO:0005575&subject=FlyBase:FBgn0024288
```

The Solr query is generated with Monarch golr schema in mind. While the schema between Monarch golr and AmiGO golr is mostly similar, the evidence model is not. More details here: https://github.com/biolink/ontobio/issues/126

This PR adds a check to see if the Solr schema is `amigo`. If it is then add the following fields to the Solr query:
- `evidence`
- `evidence_label`
- `evidence_with`
- `evidence_type`
- `evidence_type_label`
- `evidence_closure`
- `evidence_closure_label`
- `evidence_subset_closure`
- `evidence_subset_closure_label`
- `evidence_type_closure`
- `evidence_type_closure_label`

such that the results contains evidence for associations (which was previously missing).

This fix is a temporary solution and can be removed after https://github.com/biolink/ontobio/issues/126 is resolved.


**EDIT:** updated above field list


