### PR TITLE
gorule infrastructure and gorule 08 implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ foo:
 
 # only run local tests
 travis_test:
-	pytest tests/test_*local*.py tests/test_*parser*.py
+	pytest tests/test_*local*.py tests/test_*parser*.py tests/test_qc.py
 
 cleandist:
 	rm dist/* || true

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -95,6 +95,7 @@ class Report():
     OBSOLETE_CLASS_NO_REPLACEMENT = "Obsolete class with no replacement"
     WRONG_NUMBER_OF_COLUMNS = "Wrong number of columns in this line"
     EXTENSION_SYNTAX_ERROR = "Syntax error in annotation extension field"
+    VIOLATES_GO_RULE = "Violates GO Rule"
 
     """
     3 warning levels

--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -151,10 +151,12 @@ class GafParser(assocparser.AssocParser):
             if result.result_type == qc.ResultType.WARNING:
                 self.report.warning(line, assocparser.Report.VIOLATES_GO_RULE, goid,
                                     msg="{id}: {message}".format(id=rule_id, message=result.message))
+                return assocparser.ParseResult(line, [], True)
 
             if result.result_type == qc.ResultType.ERROR:
                 self.report.error(line, assocparser.Report.VIOLATES_GO_RULE, goid,
                                     msg="{id}: {message}".format(id=rule_id, message=result.message))
+                return assocparser.ParseResult(line, [], True)
 
         ## --
         ## end of line re-processing
@@ -249,6 +251,7 @@ class GafParser(assocparser.AssocParser):
             assoc['object_extensions'] = {'union_of': object_or_exprs}
 
         self._validate_assoc(assoc, line)
+        # logging.info("Association success: {subject} {rel} {obj}".format(subject=assoc["subject"], rel=assoc["relation"]["id"], obj=assoc["object"]))
 
         return assocparser.ParseResult(line, [assoc], False, evidence.upper())
 

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -1,0 +1,62 @@
+import json
+import enum
+import collections
+
+from typing import List, Dict
+from ontobio import ontol
+
+FailMode = enum.Enum("FailMode", {"SOFT": "soft", "HARD": "hard"})
+ResultType = enum.Enum("Result", {"PASS": "Pass", "WARNING": "Warning", "ERROR": "Error"})
+TestResult = collections.namedtuple("TestResult", ["result_type", "message"])
+
+def result(passes: bool, fail_mode: FailMode) -> ResultType:
+    if passes:
+        return ResultType.PASS
+
+    # Else we didn't pass
+    if fail_mode == FailMode.SOFT:
+        return ResultType.WARNING
+
+    if fail_mode == FailMode.HARD:
+        return ResultType.ERROR
+
+
+class GoRule(object):
+
+    def __init__(self, id, title, fail_mode: FailMode):
+        self.id = id
+        self.title = title
+        self.fail_mode = fail_mode
+
+
+class GoRule08(GoRule):
+
+    def __init__(self):
+        super().__init__("GORULE:0000008", "No annotations should be made to uninformatively high level terms", FailMode.HARD)
+
+    def test(self, annotation: List, ontology: ontol.Ontology) -> TestResult:
+        if ontology is None:
+            ontology = ontol.Ontology()
+
+        goid = annotation[4]
+        evidence = annotation[6]
+
+        do_not_annotate = ontology.extract_subset("gocheck_do_not_annotate")
+        do_not_manually_annotate = ontology.extract_subset("gocheck_do_not_manually_annotate")
+
+        auto_annotated = evidence == "IEA" and goid in do_not_annotate
+        manually_annotated = evidence != "IEA" and goid in do_not_manually_annotate
+        not_high_level = not (auto_annotated or manually_annotated)
+
+        t = result(not_high_level, self.fail_mode)
+        return TestResult(t, self.title)
+
+GoRules = enum.Enum("GoRules", {"GoRule08": GoRule08()})
+
+def test_go_rules(annotation: List, ontology: ontol.Ontology) -> Dict[str, TestResult]:
+    all_results = {}
+    for rule in list(GoRules):
+        result = rule.value.test(annotation, ontology)
+        all_results[rule.value.id] = result
+
+    return all_results

--- a/tests/resources/goslim_generic.json
+++ b/tests/resources/goslim_generic.json
@@ -1,0 +1,10060 @@
+{
+  "graphs" : [ {
+    "nodes" : [ {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005615",
+      "meta" : {
+        "definition" : {
+          "val" : "That part of a multicellular organism outside the cells proper, usually taken to be outside the plasma membranes, and occupied by fluid.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1425028079"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "intercellular space",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that for multicellular organisms, the extracellular space refers to everything outside a cell, but still within the organism (excluding the extracellular matrix). Gene products from a multi-cellular organism that are secreted from a cell into the interstitial fluid or blood can therefore be annotated to this term."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "extracellular space"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005737",
+      "meta" : {
+        "definition" : {
+          "val" : "All of the contents of a cell excluding the plasma membrane and nucleus, but including other subcellular structures.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cytoplasm"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoplasm"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003677",
+      "meta" : {
+        "definition" : {
+          "val" : "Any molecular function by which a gene product interacts selectively and non-covalently with DNA (deoxyribonucleic acid).",
+          "xrefs" : [ "GOC:dph", "GOC:jl", "GOC:tb", "GOC:vw" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "plasmid binding",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "microtubule/chromatin interaction",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "structure specific DNA binding",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "structure-specific DNA binding",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0043566"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "DNA binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016192",
+      "meta" : {
+        "definition" : {
+          "val" : "A cellular transport process in which transported substances are moved in membrane-bounded vesicles; transported substances are enclosed in the vesicle lumen or located in the vesicle membrane. The process begins with a step that directs a substance to the forming vesicle, and includes vesicle budding and coating. Vesicles are then targeted to, and fuse with, an acceptor membrane.",
+          "xrefs" : [ "GOC:ai", "GOC:mah", "ISBN:08789310662000" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "vesicle transport",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "vesicular transport",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "nonselective vesicle transport",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "protein sorting along secretory pathway",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "vesicle trafficking",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0006899"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "vesicle-mediated transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005856",
+      "meta" : {
+        "definition" : {
+          "val" : "Any of the various filamentous elements that form the internal framework of cells, and typically remain after treatment of the cells with mild detergent to remove membrane constituents and soluble components of the cytoplasm. The term embraces intermediate filaments, microfilaments, microtubules, the microtrabecular lattice, and other structures characterized by a polymeric filamentous nature and long-range order within the cell. The various elements of the cytoskeleton not only serve in the maintenance of cellular shape but also have roles in other cellular functions, including cellular movement, cell division, endocytosis, and movement of organelles.",
+          "xrefs" : [ "GOC:mah", "ISBN:0198547684", "PMID:16959967" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cytoskeleton"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoskeleton"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003674",
+      "meta" : {
+        "definition" : {
+          "val" : "The actions of a single gene product or complex at the molecular level consisting of a single biochemical activity or multiple causally linked biochemical activities. A given gene product may exhibit one or more molecular functions.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "molecular function",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that, in addition to forming the root of the molecular function ontology, this term is recommended for use for the annotation of gene products whose molecular function is unknown. When this term is used for annotation, it indicates that no information was available about the molecular function of the gene product annotated as of the date the annotation was made; the evidence code ND, no data, is used to indicate this. Despite its name, this is not a type of 'function' in the sense typically defined by upper ontologies such as Basic Formal Ontology (BFO). It is instead a BFO:process carried out by a single gene product or complex."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0005554"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "molecular_function"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005975",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving carbohydrates, any of a group of organic compounds based of the general formula Cx(H2O)y. Includes the formation of carbohydrate derivatives by the addition of a carbohydrate residue to another molecule.",
+          "xrefs" : [ "GOC:mah", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_96375"
+        }, {
+          "val" : "Reactome:REACT_98394"
+        }, {
+          "val" : "Reactome:REACT_88330"
+        }, {
+          "val" : "Reactome:REACT_83329"
+        }, {
+          "val" : "Reactome:REACT_103806"
+        }, {
+          "val" : "Reactome:REACT_77669"
+        }, {
+          "val" : "Reactome:REACT_32291"
+        }, {
+          "val" : "Reactome:REACT_83038"
+        }, {
+          "val" : "Reactome:REACT_33141"
+        }, {
+          "val" : "Reactome:REACT_90099"
+        }, {
+          "val" : "Reactome:REACT_34800"
+        }, {
+          "val" : "Reactome:REACT_33953"
+        }, {
+          "val" : "Reactome:REACT_88558"
+        }, {
+          "val" : "Reactome:REACT_105321"
+        }, {
+          "val" : "Reactome:REACT_102834"
+        }, {
+          "val" : "Reactome:REACT_474"
+        }, {
+          "val" : "Reactome:REACT_115733"
+        }, {
+          "val" : "Reactome:REACT_28218"
+        }, {
+          "val" : "Wikipedia:Carbohydrate_metabolism"
+        }, {
+          "val" : "Reactome:REACT_107409"
+        }, {
+          "val" : "Reactome:REACT_104502"
+        }, {
+          "val" : "Reactome:REACT_106046"
+        }, {
+          "val" : "Reactome:REACT_81945"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single-organism carbohydrate metabolic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "multicellular organismal carbohydrate metabolic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "carbohydrate metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2012-10-23T15:40:34Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "janelomax"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044261"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044723"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "carbohydrate metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005730",
+      "meta" : {
+        "definition" : {
+          "val" : "A small, dense body one or more of which are present in the nucleus of eukaryotic cells. It is rich in RNA and protein, is not bounded by a limiting membrane, and is not seen during mitosis. Its prime function is the transcription of the nucleolar DNA into 45S ribosomal-precursor RNA, the processing of this RNA into 5.8S, 18S, and 28S components of ribosomal RNA, and the association of these components with 5S RNA and proteins synthesized outside the nucleolus. This association results in the formation of ribonucleoprotein precursors; these pass into the cytoplasm and mature into the 40S and 60S subunits of the ribosome.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1820400233"
+        }, {
+          "val" : "Wikipedia:Nucleolus"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nucleolus"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008565",
+      "meta" : {
+        "definition" : {
+          "val" : "Enables the directed movement of proteins into, out of or within a cell, or between cells.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "secretin",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein carrier activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "enzyme transporter activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "holin",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein transport chaperone",
+          "xrefs" : [ "GOC:dph", "GOC:mah", "GOC:tb" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0015463"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein transporter activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0065003",
+      "meta" : {
+        "definition" : {
+          "val" : "The aggregation, arrangement and bonding together of a set of macromolecules to form a protein-containing complex.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "protein complex formation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "protein complex assembly",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "macromolecular complex assembly",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "macromolecule complex assembly",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chaperone activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0006461"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein-containing complex assembly"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016746",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the transfer of an acyl group from one compound (donor) to another (acceptor).",
+          "xrefs" : [ "GOC:jl", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "EC:2.3"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "acyltransferase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0008415"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transferase activity, transferring acyl groups"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009536",
+      "meta" : {
+        "definition" : {
+          "val" : "Any member of a family of organelles found in the cytoplasm of plants and some protists, which are membrane-bounded and contain DNA. Plant plastids develop from a common type, the proplastid.",
+          "xrefs" : [ "GOC:jl", "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Plastid"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "plastid"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Aspergillus GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0098602",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0007155"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005618",
+      "meta" : {
+        "definition" : {
+          "val" : "The rigid or semi-rigid envelope lying outside the cell membrane of plant, fungal, most prokaryotic cells and some protozoan parasites, maintaining their shape and protecting them from osmotic lysis. In plants it is made of cellulose and, often, lignin; in fungi it is composed largely of polysaccharides; in bacteria it is composed of peptidoglycan; in protozoan parasites such as Giardia species, it's made of carbohydrates and proteins.",
+          "xrefs" : [ "GOC:giardia", "ISBN:0198547684", "PMID:15134259", "http://en.wikipedia.org/wiki/Microbial_cyst" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cell_wall"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell wall"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005739",
+      "meta" : {
+        "definition" : {
+          "val" : "A semiautonomous, self replicating organelle that occurs in varying numbers, shapes, and sizes in the cytoplasm of virtually all eukaryotic cells. It is notably the site of tissue respiration.",
+          "xrefs" : [ "GOC:giardia", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Mitochondrion"
+        }, {
+          "val" : "NIF_Subcellular:sao1860313010"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "mitochondria",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Some anaerobic or microaerophilic organisms (e.g. Entamoeba histolytica, Giardia intestinalis and several Microsporidia species) do not have mitochondria, and contain mitochondrion-related organelles (MROs) instead, called mitosomes or hydrogenosomes, very likely derived from mitochondria. To annotate gene products located in these mitochondrial relics in species such as Entamoeba histolytica, Giardia intestinalis or others, please use GO:0032047 'mitosome' or GO:0042566 'hydrogenosome'. (See PMID:24316280 for a list of species currently known to contain mitochondrion-related organelles.)"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mitochondrion"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0023033",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0007165"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005622",
+      "meta" : {
+        "definition" : {
+          "val" : "The living contents of a cell; the matter contained within (but not including) the plasma membrane, usually taken to exclude large vacuoles and masses of secretory or ingested material. In eukaryotes it includes the nucleus and cytoplasm.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Intracellular"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "protoplast",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "nucleocytoplasm",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "internal to cell",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protoplasm",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "intracellular"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007009",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of the plasma membrane.",
+          "xrefs" : [ "GOC:dph", "GOC:jl", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "plasma membrane organisation",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "plasma membrane organization and biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "plasma membrane organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008219",
+      "meta" : {
+        "definition" : {
+          "val" : "Any biological process that results in permanent cessation of all vital functions of a cell. A cell should be considered dead when any one of the following molecular or morphological criteria is met: (1) the cell has lost the integrity of its plasma membrane; (2) the cell, including its nucleus, has undergone complete fragmentation into discrete bodies (frequently referred to as apoptotic bodies). The cell corpse (or its fragments) may be engulfed by an adjacent cell in vivo, but engulfment of whole cells should not be considered a strict criteria to define cell death as, under some circumstances, live engulfed cells can be released from phagosomes (see PMID:18045538).",
+          "xrefs" : [ "GOC:mah", "GOC:mtg_apoptosis", "PMID:25236395" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "accidental cell death",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "necrosis",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "This term should not be used for direct annotation. The only exception should be when experimental data (e.g., staining with trypan blue or propidium iodide) show that cell death has occurred, but fail to provide details on death modality (accidental versus programmed). When information is provided on the cell death mechanism, annotations should be made to the appropriate descendant of 'cell death' (such as, but not limited to, GO:0097300 'programmed necrotic cell death' or GO:0006915 'apoptotic process'). Also, if experimental data suggest that a gene product influences cell death indirectly, rather than being involved in the death process directly, consider annotating to a 'regulation' term."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell death"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005623",
+      "meta" : {
+        "definition" : {
+          "val" : "The basic structural and functional unit of all organisms. Includes the plasma membrane and any external encapsulating structures such as the cell wall and cell envelope.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1813327414"
+        }, {
+          "val" : "Wikipedia:Cell_(biology)"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000589",
+          "val" : "cell and encapsulating structures"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0048590",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0040007"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007005",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of a mitochondrion; includes mitochondrial morphogenesis and distribution, and replication of the mitochondrial genome as well as synthesis of new mitochondrial components.",
+          "xrefs" : [ "GOC:dph", "GOC:jl", "GOC:mah", "GOC:sgd_curators", "PMID:9786946" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "mitochondria organization",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "mitochondrion organisation",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "mitochondrion organization and biogenesis",
+          "xrefs" : [ "GOC:curators" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mitochondrion organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006399",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving tRNA, transfer RNA, a class of relatively small RNA molecules responsible for mediating the insertion of amino acids into the sequence of nascent polypeptide chains during protein synthesis. Transfer RNA is characterized by the presence of many unusual minor bases, the function of which has not been completely established.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "tRNA metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tRNA metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0042254",
+      "meta" : {
+        "definition" : {
+          "val" : "A cellular process that results in the biosynthesis of constituent macromolecules, assembly, and arrangement of constituent parts of ribosome subunits; includes transport to the sites of protein synthesis.",
+          "xrefs" : [ "GOC:ma", "PMID:26404467", "Wikipedia:Ribosome_biogenesis" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "ribosome biogenesis and assembly",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007046"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ribosome biogenesis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006950",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process that results in a change in state or activity of a cell or an organism (in terms of movement, secretion, enzyme production, gene expression, etc.) as a result of a disturbance in organismal or cellular homeostasis, usually, but not necessarily, exogenous (e.g. temperature, humidity, ionizing radiation).",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_manually_annotate", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "response to biotic stress",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "response to abiotic stress",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term is in the subset of terms that should not be used for direct gene product annotation. Instead, select a child term or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation QC."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "response to stress"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006397",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process involved in the conversion of a primary mRNA transcript into one or more mature mRNA(s) prior to translation into polypeptide.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_1768"
+        }, {
+          "val" : "Reactome:REACT_107308"
+        }, {
+          "val" : "Reactome:REACT_97436"
+        }, {
+          "val" : "Reactome:REACT_100203"
+        }, {
+          "val" : "Reactome:REACT_94083"
+        }, {
+          "val" : "Reactome:REACT_82691"
+        }, {
+          "val" : "Reactome:REACT_96661"
+        }, {
+          "val" : "Reactome:REACT_109953"
+        }, {
+          "val" : "Reactome:REACT_114358"
+        }, {
+          "val" : "Reactome:REACT_115262"
+        }, {
+          "val" : "Reactome:REACT_91511"
+        }, {
+          "val" : "Reactome:REACT_93186"
+        }, {
+          "val" : "Reactome:REACT_97412"
+        }, {
+          "val" : "Reactome:REACT_113864"
+        }, {
+          "val" : "Reactome:REACT_33642"
+        }, {
+          "val" : "Reactome:REACT_32742"
+        }, {
+          "val" : "Reactome:REACT_90366"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "mRNA maturation",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mRNA processing"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002161",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002161"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#is_metadata_tag",
+          "val" : "true"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "never_in_taxon"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#is_class_level",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000425",
+          "val" : "Class: ?X DisjointWith: RO_0002162 some ?Y"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "never_in_taxon"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007001",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0051276"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009790",
+      "meta" : {
+        "definition" : {
+          "val" : "The process whose specific outcome is the progression of an embryo from its formation until the end of its embryonic life stage. The end of the embryonic stage is organism-specific. For example, for mammals, the process would begin with zygote formation and end with birth. For insects, the process would begin at zygote formation and end with larval hatching. For plant zygotic embryos, this would be from zygote formation to the end of seed dormancy. For plant vegetative embryos, this would be from the initial determination of the cell or group of cells to form an embryo until the point when the embryo becomes independent of the parent plant.",
+          "xrefs" : [ "GOC:go_curators", "GOC:isa_complete", "GOC:mtg_sensu" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_manually_annotate" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Embryogenesis"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasBroadSynonym",
+          "val" : "embryogenesis and morphogenesis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "embryonal development",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "embryogenesis",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0009795"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "embryo development"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005062",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0004871"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016757",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the transfer of a glycosyl group from one compound (donor) to another (acceptor).",
+          "xrefs" : [ "GOC:jl", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "EC:2.4"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "glycosyltransferase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "transglycosidase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "transglycosylase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "transferase activity, transferring other glycosyl groups",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that enzymes of class EC:2.4.99.- should also be annotated to this term."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016932"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transferase activity, transferring glycosyl groups"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016874",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the joining of two substances, or two groups within a single molecule, with the concomitant hydrolysis of the diphosphate bond in ATP or a similar triphosphate.",
+          "xrefs" : [ "EC:6", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse" ],
+        "xrefs" : [ {
+          "val" : "EC:6"
+        }, {
+          "val" : "Reactome:REACT_115603"
+        }, {
+          "val" : "Reactome:REACT_116018"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "synthetase activity",
+          "xrefs" : [ "GOC:jh2" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ligase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0051082",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with an unfolded protein.",
+          "xrefs" : [ "GOC:ai" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "binding unfolded ER proteins",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "ribosomal chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "histone-specific chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "glycoprotein-specific chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "fimbrium-specific chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "tubulin-specific chaperone activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "unfolded protein binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043226",
+      "meta" : {
+        "definition" : {
+          "val" : "Organized structure of distinctive morphology and function. Includes the nucleus, mitochondria, plastids, vacuoles, vesicles, ribosomes and the cytoskeleton, and prokaryotic structures such as anammoxosomes and pirellulosomes. Excludes the plasma membrane.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Organelle"
+        }, {
+          "val" : "NIF_Subcellular:sao1539965131"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "organelle"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym",
+      "type" : "PROPERTY",
+      "lbl" : "has_related_synonym"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043234",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0032991"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043473",
+      "meta" : {
+        "definition" : {
+          "val" : "The accumulation of pigment in an organism, tissue or cell, either by increased deposition or by increased number of cells.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "pigmentation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016044",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0061024"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030234",
+      "meta" : {
+        "definition" : {
+          "val" : "Binds to and modulates the activity of an enzyme.",
+          "xrefs" : [ "GOC:dph", "GOC:mah", "GOC:tb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "metalloenzyme regulator activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "enzyme modulator",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "catalytic regulator activity",
+          "xrefs" : [ "GOC:dph" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "GO:0030234 is reserved for cases when the regulator directly interacts with the enzyme. When regulation of enzyme activity is achieved without enzyme binding, or when the mechanism of regulation is unknown, instead annotate to 'regulation of catalytic activity ; GO:0050790'."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0010576"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "enzyme regulator activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0022857",
+      "meta" : {
+        "definition" : {
+          "val" : "Enables the transfer of a substance, usually a specific substance or a group of related substances, from one side of a membrane to the other.",
+          "xrefs" : [ "GOC:jid", "GOC:mtg_transport", "ISBN:0815340729" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_81225"
+        }, {
+          "val" : "Reactome:REACT_113047"
+        }, {
+          "val" : "Reactome:REACT_77235"
+        }, {
+          "val" : "Reactome:REACT_94185"
+        }, {
+          "val" : "Reactome:REACT_113116"
+        }, {
+          "val" : "Reactome:REACT_106735"
+        }, {
+          "val" : "Reactome:REACT_91849"
+        }, {
+          "val" : "Reactome:REACT_19288"
+        }, {
+          "val" : "Reactome:REACT_111088"
+        }, {
+          "val" : "Reactome:REACT_111933"
+        }, {
+          "val" : "Reactome:REACT_114161"
+        }, {
+          "val" : "Reactome:REACT_100033"
+        }, {
+          "val" : "Reactome:REACT_113829"
+        }, {
+          "val" : "Reactome:REACT_88503"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "substrate-specific transporter activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "uptake permease activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "substrate-specific transmembrane transporter activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "uptake transmembrane transporter activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0005386"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0015646"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0015563"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0022892"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0022891"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transmembrane transporter activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0071941",
+      "meta" : {
+        "definition" : {
+          "val" : "A nitrogen compound metabolic process that contributes to the nitrogen cycle. The nitrogen cycle is a series of metabolic pathways by which nitrogen is converted between various forms and redox states; it encompasses pathways in which nitrogen is acted upon directly, such as nitrification, denitrification, nitrogen fixation, and mineralization.",
+          "xrefs" : [ "GOC:mah", "PMID:16675690", "Wikipedia:Nitrogen_cycle" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Nitrogen_cycle"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2010-09-30T05:21:03Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "midori"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nitrogen cycle metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0022618",
+      "meta" : {
+        "definition" : {
+          "val" : "The aggregation, arrangement and bonding together of proteins and RNA molecules to form a ribonucleoprotein complex.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "RNP complex assembly",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "RNA-protein complex assembly",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein-RNA complex assembly",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ribonucleoprotein complex assembly"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0051301",
+      "meta" : {
+        "definition" : {
+          "val" : "The process resulting in division and partitioning of components of a cell to form more cells; may or may not be accompanied by the physical separation of a cell into distinct, individually membrane-bounded daughter cells.",
+          "xrefs" : [ "GOC:di", "GOC:go_curators", "GOC:pr" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cell_division"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term differs from 'cytokinesis ; GO:0000910' in that cytokinesis does not include nuclear division."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell division"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006810",
+      "meta" : {
+        "definition" : {
+          "val" : "The directed movement of substances (such as macromolecules, small molecules, ions) or cellular components (such as complexes and organelles) into, out of or within a cell, or between cells, or within a multicellular organism by means of some agent such as a transporter, pore or motor protein.",
+          "xrefs" : [ "GOC:dos", "GOC:dph", "GOC:jl", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_annotate", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "solute:solute exchange",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single-organism transport",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "small molecule transport",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0015457"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2012-12-13T16:25:32Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "janelomax"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044765"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0015460"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term should not be used for direct annotation. It should be possible to make a more specific annotation to one of the children of this term, for e.g. to transmembrane transport, to microtubule-based transport or to vesicle-mediated transport."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005840",
+      "meta" : {
+        "definition" : {
+          "val" : "An intracellular organelle, about 200 A in diameter, consisting of RNA and protein. It is the site of protein biosynthesis resulting from translation of messenger RNA (mRNA). It consists of two subunits, one large and one small, each containing only protein and RNA. Both the ribosome and its subunits are characterized by their sedimentation coefficients, expressed in Svedberg units (symbol: S). Hence, the prokaryotic ribosome (70S) comprises a large (50S) subunit and a small (30S) subunit, while the eukaryotic ribosome (80S) comprises a large (60S) subunit and a small (40S) subunit. Two sites on the ribosomal large subunit are involved in translation, namely the aminoacyl site (A site) and peptidyl site (P site). Ribosomes from prokaryotes, eukaryotes, mitochondria, and chloroplasts have characteristically distinct ribosomal proteins.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1429207766"
+        }, {
+          "val" : "Wikipedia:Ribosome"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "ribosomal RNA",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "membrane bound ribosome",
+          "xrefs" : [ "NIF_Subcellular:sao1291545653" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "free ribosome",
+          "xrefs" : [ "NIF_Subcellular:sao1139385046" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0033279"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ribosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006259",
+      "meta" : {
+        "definition" : {
+          "val" : "Any cellular metabolic process involving deoxyribonucleic acid. This is one of the two main types of nucleic acid, consisting of a long, unbranched macromolecule formed from one, or more commonly, two, strands of linked deoxyribonucleotides.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "DNA metabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular DNA metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0055132"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "DNA metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000278",
+      "meta" : {
+        "definition" : {
+          "val" : "Progression through the phases of the mitotic cell cycle, the most common eukaryotic cell cycle, which canonically comprises four successive phases called G1, S, G2, and M and includes replication of the genome and the subsequent segregation of chromosomes into daughter cells. In some variant cell cycles nuclear replication or nuclear division may not be followed by cell division, or G1 and G2 phases may be absent.",
+          "xrefs" : [ "GOC:mah", "ISBN:0815316194", "Reactome:69278" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_105856"
+        }, {
+          "val" : "Reactome:REACT_108233"
+        }, {
+          "val" : "Wikipedia:Mitosis"
+        }, {
+          "val" : "Reactome:REACT_104035"
+        }, {
+          "val" : "Reactome:REACT_28953"
+        }, {
+          "val" : "Reactome:REACT_85950"
+        }, {
+          "val" : "Reactome:REACT_97744"
+        }, {
+          "val" : "Reactome:REACT_90846"
+        }, {
+          "val" : "Reactome:REACT_85137"
+        }, {
+          "val" : "Reactome:REACT_96281"
+        }, {
+          "val" : "Reactome:REACT_98208"
+        }, {
+          "val" : "Reactome:REACT_28464"
+        }, {
+          "val" : "Reactome:REACT_53493"
+        }, {
+          "val" : "Reactome:REACT_84794"
+        }, {
+          "val" : "Reactome:REACT_33388"
+        }, {
+          "val" : "Reactome:REACT_90332"
+        }, {
+          "val" : "Reactome:REACT_79085"
+        }, {
+          "val" : "Reactome:REACT_100451"
+        }, {
+          "val" : "Reactome:REACT_152"
+        }, {
+          "val" : "Reactome:REACT_104195"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "mitosis",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007067"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mitotic cell cycle"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044699",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0008150"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0004871",
+      "meta" : {
+        "definition" : {
+          "val" : "Conveys a signal across a cell to trigger a change in cell function or state. A signal is a physical entity or change in state that is used to transfer information in order to trigger a response.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "hematopoietin/interferon-class (D200-domain) cytokine receptor signal transducer activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "quorum sensing response regulator activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "quorum sensing signal generator activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0005062"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0009370"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0009369"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Ligands do NOT have the molecular function 'signal transducer activity'."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "signal transducer activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0042393",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with a histone, any of a group of water-soluble proteins found in association with the DNA of eukaroytic chromosomes. They are involved in the condensation and coiling of chromosomes during cell division and have also been implicated in nonspecific suppression of gene activity.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "histone-specific chaperone activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "histone binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007582",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0008150"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0015646",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0022857"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016853",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the geometric or structural changes within one molecule. Isomerase is the systematic name for any enzyme of EC class 5.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida" ],
+        "xrefs" : [ {
+          "val" : "EC:5"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "other isomerase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that enzymes of class EC:5.99.-.- should also be annotated to this term."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "isomerase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000425",
+      "type" : "PROPERTY",
+      "lbl" : "expand assertion to"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0004518",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the hydrolysis of ester linkages within nucleic acids.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "EC:3.1"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that 'tRNA nucleotidyltransferase activity ; GO:0009022', also known as 'ribonuclease PH', and 'DNA-(apurinic or apyrimidinic site) lyase activity ; GO:0003906' do not have parentage in the 'nuclease activity' branch of the ontology because both GO and the Enzyme Commission define nuclease activity as a type of hydrolysis."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nuclease activity"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+      "type" : "PROPERTY",
+      "lbl" : "has_alternative_id"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0022607",
+      "meta" : {
+        "definition" : {
+          "val" : "The aggregation, arrangement and bonding together of a cellular component.",
+          "xrefs" : [ "GOC:isa_complete" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell structure assembly",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular component assembly at cellular level",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0071844"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cellular component assembly"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Fission yeast GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0045790",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0000902"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0045791",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0000902"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005811",
+      "meta" : {
+        "definition" : {
+          "val" : "An intracellular non-membrane-bounded organelle comprising a matrix of coalesced lipids surrounded by a phospholipid monolayer. May include associated proteins.",
+          "xrefs" : [ "GOC:mah", "GOC:tb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "lipid particle",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "lipid body",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "adiposome",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term does not refer to vesicles, but instead to structures in which lipids do not necessarily form bilayers."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "lipid droplet"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0072372",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005929"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#termgenie_unvetted",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Terms created by TermGenie that do not follow a template and require additional vetting by editors"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000004",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0008150"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000003",
+      "meta" : {
+        "definition" : {
+          "val" : "The production of new individuals that contain some portion of genetic material inherited from one or more parent organisms.",
+          "xrefs" : [ "GOC:go_curators", "GOC:isa_complete", "GOC:jl", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Reproduction"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "reproductive physiological process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0019952"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0050876"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "reproduction"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_annotate",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Term not to be used for direct annotation"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006464",
+      "meta" : {
+        "definition" : {
+          "val" : "The covalent alteration of one or more amino acids occurring in proteins, peptides and nascent polypeptides (co-translational, post-translational modifications) occurring at the level of an individual cell. Includes the modification of charged tRNAs that are destined to occur in a protein (pre-translation modification).",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "process resulting in protein modification",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "protein modification process",
+          "xrefs" : [ "GOC:bf", "GOC:jl" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "protein tagging activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cellular protein modification process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0015979",
+      "meta" : {
+        "definition" : {
+          "val" : "The synthesis by organisms of organic chemical compounds, especially carbohydrates, from carbon dioxide (CO2) using energy obtained from light rather than from the oxidation of chemical compounds.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Photosynthesis"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "photosynthesis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009058",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways resulting in the formation of substances; typically the energy-requiring part of metabolism in which simpler substances are transformed into more complex ones.",
+          "xrefs" : [ "GOC:curators", "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Anabolism"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "synthesis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "formation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "anabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single-organism biosynthetic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "multicellular organismal biosynthetic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "biosynthesis",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044711"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "janelomax"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044274"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2012-10-17T15:52:18Z"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "biosynthetic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006461",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0065003"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009056",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways resulting in the breakdown of substances, including the breakdown of carbon compounds with the liberation of energy for use by the cell or organism.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Catabolism"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "breakdown",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single-organism catabolic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "catabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "degradation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "multicellular organismal catabolic process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2012-10-17T15:52:35Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044243"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044712"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "janelomax"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "catabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016829",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the cleavage of C-C, C-O, C-N and other bonds by other means than by hydrolysis or oxidation, or conversely adding a group to a double bond. They differ from other enzymes in that two substrates are involved in one reaction direction, but only one in the other direction. When acting on the single substrate, a molecule is eliminated and this generates either a new double bond or a new ring.",
+          "xrefs" : [ "EC:4.-.-.-", "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "EC:4"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "other lyase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that enzymes of class EC:4.99.-.- should also be annotated to this term."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "lyase activity"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty",
+      "type" : "PROPERTY",
+      "lbl" : "synonym_type_property"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008092",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with any protein component of any cytoskeleton (actin, microtubule, or intermediate filament cytoskeleton).",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoskeletal protein binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0019899",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with any enzyme.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "enzyme binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Plant GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0071844",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0022607"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016023",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0031410"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0032991",
+      "meta" : {
+        "definition" : {
+          "val" : "A stable assembly of two or more macromolecules, i.e. proteins, nucleic acids, carbohydrates or lipids, in which at least one component is a protein and the constituent parts function together.",
+          "xrefs" : [ "GOC:dos", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "protein containing complex",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "macromolecule complex",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "macromolecular complex",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein complex",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein-protein complex",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "A protein complex in this context is meant as a stable set of interacting proteins which can be co-purified by an acceptable method, and where the complex has been shown to exist as an isolated, functional unit in vivo. Acceptable experimental methods include stringent protein purification followed by detection of protein interaction. The following methods should be considered non-acceptable: simple immunoprecipitation, pull-down experiments from cell extracts without further purification, colocalization and 2-hybrid screening. Interactions that should not be captured as protein complexes include: 1) enzyme/substrate, receptor/ligand or any similar transient interactions, unless these are a critical part of the complex assembly or are required e.g. for the receptor to be functional; 2) proteins associated in a pull-down/co-immunoprecipitation assay with no functional link or any evidence that this is a defined biological entity rather than a loose-affinity complex; 3) any complex where the only evidence is based on genetic interaction data; 4) partial complexes, where some subunits (e.g. transmembrane ones) cannot be expressed as recombinant proteins and are excluded from experiments (in this case, independent evidence is necessary to find out the composition of the full complex, if known). Interactions that may be captured as protein complexes include: 1) enzyme/substrate or receptor/ligand if the complex can only assemble and become functional in the presence of both classes of subunits; 2) complexes where one of the members has not been shown to be physically linked to the other(s), but is a homologue of, and has the same functionality as, a protein that has been experimentally demonstrated to form a complex with the other member(s); 3) complexes whose existence is accepted based on localization and pharmacological studies, but for which experimental evidence is not yet available for the complex as a whole."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0043234"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein-containing complex"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Yeast GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005815",
+      "meta" : {
+        "definition" : {
+          "val" : "An intracellular structure that can catalyze gamma-tubulin-dependent microtubule nucleation and that can anchor microtubules by interacting with their minus ends, plus ends or sides.",
+          "xrefs" : [ "GOC:vw", "ISBN:0815316194", "PMID:17072892", "PMID:17245416", "http://en.wikipedia.org/wiki/Microtubule_organizing_center" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Microtubule_organizing_center"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "microtubule organising centre",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "MTOC",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "microtubule organizing center"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0032196",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process involved in mediating the movement of discrete segments of DNA between nonhomologous sites.",
+          "xrefs" : [ "GOC:jp", "ISBN:1555812090" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Transposon"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transposition"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006913",
+      "meta" : {
+        "definition" : {
+          "val" : "The directed movement of molecules between the nucleus and the cytoplasm.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "nucleocytoplasmic shuttling",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that transport through the nuclear pore complex is not transmembrane because the nuclear membrane is a double membrane, and is not traversed."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0000063"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nucleocytoplasmic transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006914",
+      "meta" : {
+        "definition" : {
+          "val" : "The cellular catabolic process in which cells digest parts of their own cytoplasm; allows for both recycling of macromolecular constituents under conditions of cellular stress and remodeling the intracellular structure for cell differentiation.",
+          "xrefs" : [ "GOC:autophagy", "ISBN:0198547684", "PMID:11099404", "PMID:9412464" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Autophagy_(cellular)"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016238"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "autophagy"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016280",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0007568"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007568",
+      "meta" : {
+        "definition" : {
+          "val" : "A developmental process that is a deterioration and loss of function over time. Aging includes loss of functions such as resistance to disease, homeostasis, and fertility, as well as wear and tear. Aging includes cellular senescence, but is more inclusive. May precede death and may succeed developmental maturation (GO:0021700).",
+          "xrefs" : [ "GOC:PO_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Aging"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "ageing",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016280"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "aging"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008415",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016746"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005386",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0022857"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000130",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003700"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0032182",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with a small conjugating protein such as ubiquitin or a ubiquitin-like protein.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "small conjugating protein binding",
+          "xrefs" : [ "GOC:dph" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ubiquitin-like protein binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0031410",
+      "meta" : {
+        "definition" : {
+          "val" : "A vesicle found in the cytoplasm of a cell.",
+          "xrefs" : [ "GOC:ai", "GOC:mah", "GOC:vesicles" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao180601769"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cytoplasmic membrane bounded vesicle",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cytoplasmic, membrane-bounded vesicle",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cytoplasmic membrane-enclosed vesicle",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016023"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoplasmic vesicle"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0033279",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005840"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goantislim_grouping",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Grouping classes that can be excluded"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005829",
+      "meta" : {
+        "definition" : {
+          "val" : "The part of the cytoplasm that does not contain organelles but which does contain other particulate matter, such as protein complexes.",
+          "xrefs" : [ "GOC:hjd", "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao101633890"
+        }, {
+          "val" : "Wikipedia:Cytosol"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytosol"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Prokaryotic GO subset"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003735",
+      "meta" : {
+        "definition" : {
+          "val" : "The action of a molecule that contributes to the structural integrity of the ribosome.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasBroadSynonym",
+          "val" : "ribosomal protein",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "ribosomal RNA",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003738"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003737"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003739"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003736"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term may be used to annotate ribosomal RNAs as well as ribosomal proteins."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003742"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003741"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003740"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "structural constituent of ribosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030312",
+      "meta" : {
+        "definition" : {
+          "val" : "A structure that lies outside the plasma membrane and surrounds the entire cell. This does not include the periplasmic space.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "The outer membrane (of gram negative bacteria) or cell wall (of yeast or Gram positive bacteria) are defined as parts of this structure, see 'external encapsulating structure part'."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "external encapsulating structure"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030555",
+      "meta" : {
+        "definition" : {
+          "val" : "Specifies the site of a posttranscriptional modification in an RNA molecule by base pairing with a short sequence around the target residue.",
+          "xrefs" : [ "GOC:mah", "PMID:12457565" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term describes the activity of a nucleic acid, usually RNA, gene product that interacts with other RNA molecules via base pairing; it should not be used to annotate proteins."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "RNA modification guide activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0004386",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the reaction: NTP + H2O = NDP + phosphate, to drive the unwinding of a DNA or RNA helix.",
+          "xrefs" : [ "GOC:mah", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_104221"
+        }, {
+          "val" : "Reactome:REACT_110845"
+        }, {
+          "val" : "Reactome:REACT_98745"
+        }, {
+          "val" : "Reactome:REACT_81682"
+        }, {
+          "val" : "Reactome:REACT_94679"
+        }, {
+          "val" : "Reactome:REACT_78771"
+        }, {
+          "val" : "Reactome:REACT_101994"
+        }, {
+          "val" : "Reactome:REACT_109035"
+        }, {
+          "val" : "Reactome:REACT_107072"
+        }, {
+          "val" : "Reactome:REACT_29818"
+        }, {
+          "val" : "Reactome:REACT_95942"
+        }, {
+          "val" : "Reactome:REACT_113177"
+        }, {
+          "val" : "Reactome:REACT_31034"
+        }, {
+          "val" : "Reactome:REACT_6184"
+        }, {
+          "val" : "Reactome:REACT_103861"
+        }, {
+          "val" : "Reactome:REACT_28343"
+        }, {
+          "val" : "Reactome:REACT_80107"
+        }, {
+          "val" : "Reactome:REACT_91822"
+        }, {
+          "val" : "Reactome:REACT_1844"
+        }, {
+          "val" : "Reactome:REACT_89694"
+        }, {
+          "val" : "Reactome:REACT_86220"
+        }, {
+          "val" : "Reactome:REACT_112208"
+        }, {
+          "val" : "Reactome:REACT_110827"
+        }, {
+          "val" : "Reactome:REACT_40"
+        }, {
+          "val" : "Reactome:REACT_29850"
+        }, {
+          "val" : "Reactome:REACT_103897"
+        }, {
+          "val" : "Reactome:REACT_78667"
+        }, {
+          "val" : "Reactome:REACT_81427"
+        }, {
+          "val" : "Reactome:REACT_93391"
+        }, {
+          "val" : "Reactome:REACT_101247"
+        }, {
+          "val" : "Reactome:REACT_1033"
+        }, {
+          "val" : "Reactome:REACT_112817"
+        }, {
+          "val" : "Reactome:REACT_28131"
+        }, {
+          "val" : "Reactome:REACT_102441"
+        }, {
+          "val" : "Reactome:REACT_80605"
+        }, {
+          "val" : "Reactome:REACT_1521"
+        }, {
+          "val" : "Reactome:REACT_85172"
+        }, {
+          "val" : "Reactome:REACT_81335"
+        }, {
+          "val" : "Reactome:REACT_89030"
+        }, {
+          "val" : "Reactome:REACT_80500"
+        }, {
+          "val" : "Reactome:REACT_30989"
+        }, {
+          "val" : "Reactome:REACT_102560"
+        }, {
+          "val" : "Reactome:REACT_108654"
+        }, {
+          "val" : "Reactome:REACT_98302"
+        }, {
+          "val" : "Reactome:REACT_6768"
+        }, {
+          "val" : "Reactome:REACT_82776"
+        }, {
+          "val" : "Reactome:REACT_6325"
+        }, {
+          "val" : "Reactome:REACT_81441"
+        }, {
+          "val" : "Reactome:REACT_106346"
+        }, {
+          "val" : "Reactome:REACT_31090"
+        }, {
+          "val" : "Reactome:REACT_108159"
+        }, {
+          "val" : "Reactome:REACT_80532"
+        }, {
+          "val" : "Reactome:REACT_103881"
+        }, {
+          "val" : "Reactome:REACT_84574"
+        }, {
+          "val" : "Reactome:REACT_95993"
+        }, {
+          "val" : "Reactome:REACT_101644"
+        }, {
+          "val" : "Reactome:REACT_103959"
+        }, {
+          "val" : "Reactome:REACT_109161"
+        }, {
+          "val" : "Reactome:REACT_98273"
+        }, {
+          "val" : "Reactome:REACT_80325"
+        }, {
+          "val" : "Reactome:REACT_89363"
+        }, {
+          "val" : "Reactome:REACT_29217"
+        }, {
+          "val" : "Reactome:REACT_101111"
+        }, {
+          "val" : "Reactome:REACT_31554"
+        }, {
+          "val" : "Reactome:REACT_101823"
+        }, {
+          "val" : "Reactome:REACT_29155"
+        }, {
+          "val" : "Reactome:REACT_78086"
+        }, {
+          "val" : "Reactome:REACT_6853"
+        }, {
+          "val" : "Reactome:REACT_102121"
+        }, {
+          "val" : "Reactome:REACT_84565"
+        }, {
+          "val" : "Reactome:REACT_6922"
+        }, {
+          "val" : "Reactome:REACT_110588"
+        }, {
+          "val" : "Reactome:REACT_101622"
+        }, {
+          "val" : "Reactome:REACT_108648"
+        }, {
+          "val" : "Reactome:REACT_34560"
+        }, {
+          "val" : "Reactome:REACT_1817"
+        }, {
+          "val" : "Reactome:REACT_30013"
+        }, {
+          "val" : "Reactome:REACT_28810"
+        }, {
+          "val" : "Reactome:REACT_78462"
+        }, {
+          "val" : "Reactome:REACT_85111"
+        }, {
+          "val" : "Reactome:REACT_99120"
+        }, {
+          "val" : "Reactome:REACT_34016"
+        }, {
+          "val" : "Reactome:REACT_32533"
+        }, {
+          "val" : "Reactome:REACT_33205"
+        }, {
+          "val" : "Reactome:REACT_6758"
+        }, {
+          "val" : "Reactome:REACT_83794"
+        }, {
+          "val" : "Reactome:REACT_34089"
+        }, {
+          "val" : "Reactome:REACT_89000"
+        }, {
+          "val" : "Reactome:REACT_28880"
+        }, {
+          "val" : "Reactome:REACT_84809"
+        }, {
+          "val" : "Reactome:REACT_107495"
+        }, {
+          "val" : "Reactome:REACT_93711"
+        }, {
+          "val" : "Reactome:REACT_81126"
+        }, {
+          "val" : "Reactome:REACT_84907"
+        }, {
+          "val" : "Reactome:REACT_94645"
+        }, {
+          "val" : "Reactome:REACT_79759"
+        }, {
+          "val" : "Reactome:REACT_105950"
+        }, {
+          "val" : "Reactome:REACT_88362"
+        }, {
+          "val" : "Reactome:REACT_6134"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that most helicases catalyze processive duplex unwinding."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "helicase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043037",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006412"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044243",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0009056"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0061024",
+      "meta" : {
+        "definition" : {
+          "val" : "A process which results in the assembly, arrangement of constituent parts, or disassembly of a membrane. A membrane is a double layer of lipid molecules that encloses all cells, and, in eukaryotes, many organelles; may be a single or double lipid bilayer; also includes associated proteins.",
+          "xrefs" : [ "GOC:dph", "GOC:tb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_93714"
+        }, {
+          "val" : "Reactome:REACT_87431"
+        }, {
+          "val" : "Reactome:REACT_78213"
+        }, {
+          "val" : "Reactome:REACT_96516"
+        }, {
+          "val" : "Reactome:REACT_95586"
+        }, {
+          "val" : "Reactome:REACT_103082"
+        }, {
+          "val" : "Reactome:REACT_101524"
+        }, {
+          "val" : "Reactome:REACT_33741"
+        }, {
+          "val" : "Reactome:REACT_97881"
+        }, {
+          "val" : "Reactome:REACT_34084"
+        }, {
+          "val" : "Reactome:REACT_32337"
+        }, {
+          "val" : "Reactome:REACT_86557"
+        }, {
+          "val" : "Reactome:REACT_88307"
+        }, {
+          "val" : "Reactome:REACT_11123"
+        }, {
+          "val" : "Reactome:REACT_91154"
+        }, {
+          "val" : "Reactome:REACT_29278"
+        }, {
+          "val" : "Reactome:REACT_78288"
+        }, {
+          "val" : "Reactome:REACT_83546"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "membrane organization and biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "membrane organisation",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular membrane organization",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular membrane organisation",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single-organism membrane organization",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "janelomax"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044802"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2010-02-08T02:43:11Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016044"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "membrane organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Mouse GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+      "type" : "PROPERTY",
+      "lbl" : "shorthand"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044802",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0061024"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000902",
+      "meta" : {
+        "definition" : {
+          "val" : "The developmental process in which the size or shape of a cell is generated and organized.",
+          "xrefs" : [ "GOC:clt", "GOC:dph", "GOC:go_curators", "GOC:tb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular morphogenesis",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007148"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0045791"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0045790"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell morphogenesis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030674",
+      "meta" : {
+        "definition" : {
+          "val" : "The binding activity of a molecule that brings together two or more protein molecules, or a protein and another macromolecule or complex, through a selective, non-covalent, often stoichiometric interaction, permitting those molecules to function in a coordinated way.",
+          "xrefs" : [ "GOC:bf", "GOC:mah", "GOC:vw" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein-protein adaptor",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein binding, bridging"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000229",
+      "meta" : {
+        "definition" : {
+          "val" : "A chromosome found in the cytoplasm.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "cytoplasmic interphase chromosome",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoplasmic chromosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000228",
+      "meta" : {
+        "definition" : {
+          "val" : "A chromosome that encodes the nuclear genome and is found in the nucleus of a eukaryotic cell during the cell cycle phases when the nucleus is intact.",
+          "xrefs" : [ "GOC:dph", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "nuclear interphase chromosome",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nuclear chromosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003737",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003736",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0055132",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006259"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_synapse",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "synapse GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003739",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#mf_needs_review",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Catalytic activity terms in need of attention"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003738",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "AGR slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0032846",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0042592"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003740",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0032845",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0042592"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0032844",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0042592"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0048856",
+      "meta" : {
+        "definition" : {
+          "val" : "The biological process whose specific outcome is the progression of an anatomical structure from an initial condition to its mature state. This process begins with the formation of the structure and ends with the mature structure, whatever form that may be including its natural destruction. An anatomical structure is any biological entity that occupies space and is distinguished from its surroundings. Anatomical structures can be macroscopic such as a carpel, or microscopic such as an acrosome.",
+          "xrefs" : [ "GOC:mtg_15jun06", "GO_REF:0000021" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "development of an anatomical structure",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "This term was added by GO_REF:0000021."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "anatomical structure development"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003742",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006457",
+      "meta" : {
+        "definition" : {
+          "val" : "The process of assisting in the covalent and noncovalent assembly of single chain polypeptides or multisubunit complexes into the correct tertiary structure.",
+          "xrefs" : [ "GOC:go_curators", "GOC:rb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_109411"
+        }, {
+          "val" : "Reactome:REACT_94123"
+        }, {
+          "val" : "Reactome:REACT_83906"
+        }, {
+          "val" : "Reactome:REACT_105663"
+        }, {
+          "val" : "Reactome:REACT_108248"
+        }, {
+          "val" : "Reactome:REACT_97220"
+        }, {
+          "val" : "Reactome:REACT_17004"
+        }, {
+          "val" : "Reactome:REACT_97016"
+        }, {
+          "val" : "Reactome:REACT_77627"
+        }, {
+          "val" : "Reactome:REACT_106894"
+        }, {
+          "val" : "Reactome:REACT_110417"
+        }, {
+          "val" : "Reactome:REACT_33395"
+        }, {
+          "val" : "Reactome:REACT_106009"
+        }, {
+          "val" : "Reactome:REACT_30906"
+        }, {
+          "val" : "Reactome:REACT_16956"
+        }, {
+          "val" : "Reactome:REACT_96773"
+        }, {
+          "val" : "Reactome:REACT_94772"
+        }, {
+          "val" : "Reactome:REACT_77963"
+        }, {
+          "val" : "Reactome:REACT_94443"
+        }, {
+          "val" : "Reactome:REACT_32255"
+        }, {
+          "val" : "Reactome:REACT_85492"
+        }, {
+          "val" : "Reactome:REACT_92961"
+        }, {
+          "val" : "Reactome:REACT_98132"
+        }, {
+          "val" : "Reactome:REACT_17001"
+        }, {
+          "val" : "Reactome:REACT_78530"
+        }, {
+          "val" : "Reactome:REACT_106927"
+        }, {
+          "val" : "Reactome:REACT_17056"
+        }, {
+          "val" : "Reactome:REACT_85496"
+        }, {
+          "val" : "Reactome:REACT_100411"
+        }, {
+          "val" : "Reactome:REACT_81155"
+        }, {
+          "val" : "Reactome:REACT_106427"
+        }, {
+          "val" : "Reactome:REACT_86318"
+        }, {
+          "val" : "Reactome:REACT_91676"
+        }, {
+          "val" : "Reactome:REACT_92785"
+        }, {
+          "val" : "Reactome:REACT_32155"
+        }, {
+          "val" : "Wikipedia:Protein_folding"
+        }, {
+          "val" : "Reactome:REACT_23878"
+        }, {
+          "val" : "Reactome:REACT_92981"
+        }, {
+          "val" : "Reactome:REACT_107029"
+        }, {
+          "val" : "Reactome:REACT_104912"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "non-chaperonin molecular chaperone ATPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chaperonin ATPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "co-chaperone activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "co-chaperonin activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "protein complex assembly, multichaperone pathway",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "chaperonin-mediated tubulin folding",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "alpha-tubulin folding",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "beta-tubulin folding",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "glycoprotein-specific chaperone activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007022"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007024"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007025"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein folding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003741",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003735"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043167",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with ions, charged atoms or groups of atoms.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "atom binding",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ion binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006453",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006412"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#syngo_official_label",
+      "lbl" : "label approved by the SynGO project"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016932",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016757"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#systematic_synonym",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasScope",
+          "val" : "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"
+        } ]
+      },
+      "lbl" : "Systematic synonym"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002213",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002213"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "positively_regulates"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "positively regulates"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016810",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the hydrolysis of any carbon-nitrogen bond, C-N, with the exception of peptide bonds.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "EC:3.5"
+        }, {
+          "val" : "Reactome:REACT_27208"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds, in other compounds",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that enzymes of class EC:3.5.99.- should also be annotated to this term."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "hydrolase activity, acting on carbon-nitrogen (but not peptide) bonds"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005929",
+      "meta" : {
+        "definition" : {
+          "val" : "A specialized eukaryotic organelle that consists of a filiform extrusion of the cell surface and of some cytoplasmic parts. Each cilium is largely bounded by an extrusion of the cytoplasmic (plasma) membrane, and contains a regular longitudinal array of microtubules, anchored to a basal body.",
+          "xrefs" : [ "GOC:cilia", "GOC:curators", "GOC:kmv", "GOC:vw", "ISBN:0198547684", "PMID:16824949", "PMID:17009929", "PMID:20144998" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao787716553"
+        }, {
+          "val" : "FMA:67181"
+        }, {
+          "val" : "Wikipedia:Cilium"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "primary cilium",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "eukaryotic flagellum",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "flagellum",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "microtubule-based flagellum",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that we deem cilium and microtubule-based flagellum to be equivalent. In most eukaryotic species, intracellular sub-components of the cilium, such as the ciliary base and rootlet, are located near the plasma membrane. In Diplomonads such as Giardia, instead, the same ciliary parts are located further intracellularly. Also, 'cilium' may be used when axonemal structure and/or motility are unknown, or when axonemal structure is unusual. For all other cases, please refer to children of 'cilium'. Finally, note that any role of ciliary proteins in sensory events should be captured by annotating to relevant biological process terms."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0072372"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cilium"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016491",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of an oxidation-reduction (redox) reaction, a reversible chemical reaction in which the oxidation state of an atom or atoms within a molecule is altered. One substrate acts as a hydrogen or electron donor and becomes oxidized, while the other acts as hydrogen or electron acceptor and becomes reduced.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_92434"
+        }, {
+          "val" : "Reactome:REACT_97234"
+        }, {
+          "val" : "Reactome:REACT_34705"
+        }, {
+          "val" : "Reactome:REACT_103874"
+        }, {
+          "val" : "Reactome:REACT_99989"
+        }, {
+          "val" : "Reactome:REACT_110582"
+        }, {
+          "val" : "Reactome:REACT_91952"
+        }, {
+          "val" : "Reactome:REACT_92075"
+        }, {
+          "val" : "Reactome:REACT_90394"
+        }, {
+          "val" : "Reactome:REACT_88304"
+        }, {
+          "val" : "Reactome:REACT_98022"
+        }, {
+          "val" : "Reactome:REACT_32960"
+        }, {
+          "val" : "Reactome:REACT_97568"
+        }, {
+          "val" : "Reactome:REACT_99085"
+        }, {
+          "val" : "Reactome:REACT_31762"
+        }, {
+          "val" : "Reactome:REACT_17006"
+        }, {
+          "val" : "Reactome:REACT_115316"
+        }, {
+          "val" : "EC:1"
+        }, {
+          "val" : "Reactome:REACT_97851"
+        }, {
+          "val" : "Reactome:REACT_105121"
+        }, {
+          "val" : "Reactome:REACT_108745"
+        }, {
+          "val" : "Reactome:REACT_95573"
+        }, {
+          "val" : "Reactome:REACT_89057"
+        }, {
+          "val" : "Reactome:REACT_95169"
+        }, {
+          "val" : "Reactome:REACT_109500"
+        }, {
+          "val" : "Reactome:REACT_15389"
+        }, {
+          "val" : "Reactome:REACT_107467"
+        }, {
+          "val" : "Reactome:REACT_105062"
+        }, {
+          "val" : "Reactome:REACT_78923"
+        }, {
+          "val" : "Reactome:REACT_104604"
+        }, {
+          "val" : "Reactome:REACT_95558"
+        }, {
+          "val" : "Reactome:REACT_29212"
+        }, {
+          "val" : "Reactome:REACT_102858"
+        }, {
+          "val" : "Reactome:REACT_17042"
+        }, {
+          "val" : "Reactome:REACT_93539"
+        }, {
+          "val" : "Reactome:REACT_44470"
+        }, {
+          "val" : "Reactome:REACT_84842"
+        }, {
+          "val" : "Reactome:REACT_30160"
+        }, {
+          "val" : "Reactome:REACT_93974"
+        }, {
+          "val" : "Reactome:REACT_106088"
+        }, {
+          "val" : "Reactome:REACT_91638"
+        }, {
+          "val" : "Reactome:REACT_102973"
+        }, {
+          "val" : "Reactome:REACT_86178"
+        }, {
+          "val" : "Reactome:REACT_106276"
+        }, {
+          "val" : "Reactome:REACT_107002"
+        }, {
+          "val" : "Reactome:REACT_15410"
+        }, {
+          "val" : "Reactome:REACT_99794"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "redox activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "oxidoreductase activity, acting on other substrates",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that enzymes of class EC:1.97.-.- should also be annotated to this term."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "oxidoreductase activity"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasScope",
+      "type" : "PROPERTY",
+      "lbl" : "has_scope"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0070882",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0071554"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003869",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016791"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044261",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005975"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005578",
+      "meta" : {
+        "definition" : {
+          "val" : "A layer consisting mainly of proteins (especially collagen) and glycosaminoglycans (mostly as proteoglycans) that forms a sheet underlying or overlying cells such as endothelial and epithelial cells. The proteins are secreted by cells in the vicinity. An example of this component is found in Mus musculus.",
+          "xrefs" : [ "GOC:mtg_sensu", "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "proteinaceous extracellular matrix"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005576",
+      "meta" : {
+        "definition" : {
+          "val" : "The space external to the outermost structure of a cell. For cells without external protective or external encapsulating structures this refers to space outside of the plasma membrane. This term covers the host cell environment outside an intracellular parasite.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Extracellular"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "extracellular",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term is intended to annotate gene products that are not attached to the cell surface. For gene products from multicellular organisms which are secreted from a cell but retained within the organism (i.e. released into the interstitial fluid or blood), consider the cellular component term 'extracellular space ; GO:0005615'."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "extracellular region"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030533",
+      "meta" : {
+        "definition" : {
+          "val" : "The codon binding activity of a tRNA that positions an activated amino acid, mediating its insertion at the correct point in the sequence of a nascent polypeptide chain during protein synthesis.",
+          "xrefs" : [ "GOC:hjd", "GOC:mtg_MIT_16mar07", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "transfer RNA",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "tRNA",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term can be used in place of the obsolete term 'transfer RNA ; GO:0005563'."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "triplet codon-amino acid adaptor activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005575",
+      "meta" : {
+        "definition" : {
+          "val" : "The part of a cell, extracellular environment or virus in which a gene product is located. A gene product may be located in one or more parts of a cell and its location may be as specific as a particular macromolecular complex, that is, a stable, persistent association of macromolecules that function together.",
+          "xrefs" : [ "GOC:go_curators", "NIF_Subcellular:sao-1337158144" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1337158144"
+        }, {
+          "val" : "NIF_Subcellular:sao-1337158144"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell or subcellular entity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular component",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "subcellular entity",
+          "xrefs" : [ "NIF_Subcellular:nlx_subcell_100315" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0008372"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that, in addition to forming the root of the cellular component ontology, this term is recommended for use for the annotation of gene products whose cellular component is unknown. Note that when this term is used for annotation, it indicates that no information was available about the cellular component of the gene product annotated as of the date the annotation was made; the evidence code ND, no data, is used to indicate this."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cellular_component"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002211",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002211"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "regulates"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "regulates"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0004002",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016887"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005694",
+      "meta" : {
+        "definition" : {
+          "val" : "A structure composed of a very long molecule of DNA and associated proteins (e.g. histones) that carries hereditary information.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Chromosome"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "prophase chromosome",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "interphase chromosome",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chromatid",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Chromosomes include parts that are not part of the chromatin.  Examples include the kinetochore."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "chromosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008289",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with a lipid.",
+          "xrefs" : [ "GOC:ai" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "lipid binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008168",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the transfer of a methyl group to an acceptor molecule.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_33644"
+        }, {
+          "val" : "Reactome:REACT_84525"
+        }, {
+          "val" : "Reactome:REACT_100745"
+        }, {
+          "val" : "Reactome:REACT_29020"
+        }, {
+          "val" : "Reactome:REACT_73401"
+        }, {
+          "val" : "Reactome:REACT_100884"
+        }, {
+          "val" : "Reactome:REACT_105909"
+        }, {
+          "val" : "Reactome:REACT_86817"
+        }, {
+          "val" : "Reactome:REACT_100863"
+        }, {
+          "val" : "Reactome:REACT_29098"
+        }, {
+          "val" : "Reactome:REACT_2094"
+        }, {
+          "val" : "EC:2.1.1"
+        }, {
+          "val" : "Reactome:REACT_87169"
+        }, {
+          "val" : "Reactome:REACT_86905"
+        }, {
+          "val" : "Reactome:REACT_93379"
+        }, {
+          "val" : "Reactome:REACT_83214"
+        }, {
+          "val" : "Reactome:REACT_15553"
+        }, {
+          "val" : "Reactome:REACT_94274"
+        }, {
+          "val" : "Reactome:REACT_106465"
+        }, {
+          "val" : "Reactome:REACT_15531"
+        }, {
+          "val" : "Reactome:REACT_33779"
+        }, {
+          "val" : "Reactome:REACT_107676"
+        }, {
+          "val" : "Reactome:REACT_79799"
+        }, {
+          "val" : "Reactome:REACT_96444"
+        }, {
+          "val" : "Reactome:REACT_84974"
+        }, {
+          "val" : "Reactome:REACT_103958"
+        }, {
+          "val" : "Reactome:REACT_105478"
+        }, {
+          "val" : "Reactome:REACT_104757"
+        }, {
+          "val" : "Reactome:REACT_93809"
+        }, {
+          "val" : "Reactome:REACT_99316"
+        }, {
+          "val" : "Reactome:REACT_78774"
+        }, {
+          "val" : "Reactome:REACT_77286"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasBroadSynonym",
+          "val" : "methylase",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0004480"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "methyltransferase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002212",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002212"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "negatively_regulates"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "negatively regulates"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0004480",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0008168"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043298",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0044403"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0034330",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of a cell junction. A cell junction is a specialized region of connection between two cells or between a cell and the extracellular matrix.",
+          "xrefs" : [ "GOC:dph", "GOC:jl", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell junction assembly and maintenance",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cell junction biogenesis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cell junction organisation",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell junction organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "BFO:0000050"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "part_of"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "part of"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044822",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003723"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0021700",
+      "meta" : {
+        "definition" : {
+          "val" : "A developmental process, independent of morphogenetic (shape) change, that is required for an anatomical structure, cell or cellular component to attain its fully functional state.",
+          "xrefs" : [ "GOC:cls", "GOC:dgh", "GOC:dph", "GOC:jid", "GOC:mtg_15jun06", "GO_REF:0000021" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "This term was added by GO_REF:0000021."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "developmental maturation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
+      "type" : "PROPERTY",
+      "lbl" : "definition"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/BFO_0000051",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "BFO:0000051"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "has_part"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "has_part"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003723",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with an RNA molecule or a portion thereof.",
+          "xrefs" : [ "GOC:jl", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_106430"
+        }, {
+          "val" : "Reactome:REACT_108368"
+        }, {
+          "val" : "Reactome:REACT_12458"
+        }, {
+          "val" : "Reactome:REACT_90531"
+        }, {
+          "val" : "Reactome:REACT_101703"
+        }, {
+          "val" : "Reactome:REACT_89329"
+        }, {
+          "val" : "Reactome:REACT_87164"
+        }, {
+          "val" : "Reactome:REACT_29965"
+        }, {
+          "val" : "Reactome:REACT_78197"
+        }, {
+          "val" : "Reactome:REACT_109723"
+        }, {
+          "val" : "Reactome:REACT_108232"
+        }, {
+          "val" : "Reactome:REACT_77167"
+        }, {
+          "val" : "Reactome:REACT_98683"
+        }, {
+          "val" : "Reactome:REACT_107757"
+        }, {
+          "val" : "Reactome:REACT_103323"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "poly(A) RNA binding",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "poly-A RNA binding",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "poly(A)-RNA binding",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044822"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "RNA binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#virus_checked",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Viral overhaul terms"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044274",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0009058"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0048870",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process involved in the controlled self-propelled movement of a cell that results in translocation of the cell from one place to another.",
+          "xrefs" : [ "GOC:dgh", "GOC:dph", "GOC:isa_complete", "GOC:mlg" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell locomotion",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "movement of a cell",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cell movement",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell motility"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006790",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving the nonmetallic element sulfur or compounds that contain sulfur, such as the amino acids methionine and cysteine or the tripeptide glutathione.",
+          "xrefs" : [ "GOC:ai" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Sulfur_metabolism"
+        }, {
+          "val" : "Reactome:REACT_27247"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "sulphur metabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "sulfur metabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "sulphur metabolic process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "sulfur compound metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0019748",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways resulting in many of the chemical changes of compounds that are not necessarily required for growth and maintenance of cells, and are often unique to a taxon. In multicellular organisms secondary metabolism is generally carried out in specific cell types, and may be useful for the organism as a whole. In unicellular organisms, secondary metabolism is often used for the production of antibiotics or for the utilization and acquisition of unusual nutrients.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Secondary_metabolism"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "secondary metabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "secondary metabolite metabolic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "secondary metabolite metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "secondary metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044711",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0009058"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044712",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0009056"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016238",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006914"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003729",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with messenger RNA (mRNA), an intermediate molecule between DNA and protein. mRNA includes UTR and coding sequences, but does not contain introns.",
+          "xrefs" : [ "GOC:kmv", "GOC:pr", "SO:0000234" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mRNA binding"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
+      "type" : "PROPERTY",
+      "lbl" : "has_narrow_synonym"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005904",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005886"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044281",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving small molecules, any low molecular weight, monomeric, non-encoded molecule.",
+          "xrefs" : [ "GOC:curators", "GOC:pde", "GOC:vw" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_114137"
+        }, {
+          "val" : "Reactome:REACT_112140"
+        }, {
+          "val" : "Reactome:REACT_113610"
+        }, {
+          "val" : "Reactome:REACT_113305"
+        }, {
+          "val" : "Reactome:REACT_113934"
+        }, {
+          "val" : "Reactome:REACT_111217"
+        }, {
+          "val" : "Reactome:REACT_113131"
+        }, {
+          "val" : "Reactome:REACT_113457"
+        }, {
+          "val" : "Reactome:REACT_114421"
+        }, {
+          "val" : "Reactome:REACT_114983"
+        }, {
+          "val" : "Reactome:REACT_115655"
+        }, {
+          "val" : "Reactome:REACT_114495"
+        }, {
+          "val" : "Reactome:REACT_113568"
+        }, {
+          "val" : "Reactome:REACT_114668"
+        }, {
+          "val" : "Reactome:REACT_112077"
+        }, {
+          "val" : "Reactome:REACT_112912"
+        }, {
+          "val" : "Reactome:REACT_114473"
+        }, {
+          "val" : "Reactome:REACT_115388"
+        }, {
+          "val" : "Reactome:REACT_112621"
+        }, {
+          "val" : "Reactome:REACT_115420"
+        }, {
+          "val" : "Reactome:REACT_114081"
+        }, {
+          "val" : "Reactome:REACT_115063"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "small molecule metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2010-01-26T12:05:20Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Small molecules in GO include monosaccharides but exclude disaccharides and polysaccharides."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "jane"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "small molecule metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003013",
+      "meta" : {
+        "definition" : {
+          "val" : "A organ system process carried out by any of the organs or tissues of the circulatory system. The circulatory system is an organ system that moves extracellular fluids to and from tissue within a multicellular organism.",
+          "xrefs" : [ "GOC:mtg_cardio" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Circulatory_system"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "circulatory system process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005554",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003674"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006520",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving amino acids, carboxylic acids containing one or more amino groups, as carried out by individual cells.",
+          "xrefs" : [ "CHEBI:33709", "GOC:curators", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_116093"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "amino acid and derivative metabolism",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "amino acid metabolic process",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular amino acid metabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular amino acid and derivative metabolic process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0006519"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cellular amino acid metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005794",
+      "meta" : {
+        "definition" : {
+          "val" : "A compound membranous cytoplasmic organelle of eukaryotic cells, consisting of flattened, ribosome-free vesicles arranged in a more or less regular stack. The Golgi apparatus differs from the endoplasmic reticulum in often having slightly thicker membranes, appearing in sections as a characteristic shallow semicircle so that the convex side (cis or entry face) abuts the endoplasmic reticulum, secretory vesicles emerging from the concave side (trans or exit face). In vertebrate cells there is usually one such organelle, while in invertebrates and plants, where they are known usually as dictyosomes, there may be several scattered in the cytoplasm. The Golgi apparatus processes proteins produced on the ribosomes of the rough endoplasmic reticulum; such processing includes modification of the core oligosaccharides of glycoproteins, and the sorting and packaging of proteins for transport to a variety of cellular locations. Three different regions of the Golgi are now recognized both in terms of structure and function: cis, in the vicinity of the cis face, trans, in the vicinity of the trans face, and medial, lying between the cis and trans regions.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao451912436"
+        }, {
+          "val" : "Wikipedia:Golgi_apparatus"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "Golgi complex",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "Golgi",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "Golgi ribbon",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that the Golgi apparatus can be located in various places in the cytoplasm. In plants and lower animal cells, the Golgi apparatus exists as many copies of discrete stacks dispersed throughout the cytoplasm, while the Golgi apparatus of interphase mammalian cells is a juxtanuclear, often pericentriolar reticulum, where the discrete Golgi stacks are stitched together to form a compact and interconnected ribbon, sometimes called the Golgi ribbon."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "Golgi apparatus"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007059",
+      "meta" : {
+        "definition" : {
+          "val" : "The process in which genetic material, in the form of chromosomes, is organized into specific structures and then physically separated and apportioned to two or more sets. In eukaryotes, chromosome segregation begins with the condensation of chromosomes, includes chromosome separation, and ends when chromosomes have completed movement to the spindle poles.",
+          "xrefs" : [ "GOC:jl", "GOC:mah", "GOC:mtg_cell_cycle", "GOC:vw" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Chromosome_segregation"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "chromosome division",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chromosome transmission",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "chromosome segregation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0048646",
+      "meta" : {
+        "definition" : {
+          "val" : "The developmental process pertaining to the initial formation of an anatomical structure from unspecified parts. This process begins with the specific processes that contribute to the appearance of the discrete structure and ends when the structural rudiment is recognizable. An anatomical structure is any biological entity that occupies space and is distinguished from its surroundings. Anatomical structures can be macroscopic such as a carpel, or microscopic such as an acrosome.",
+          "xrefs" : [ "GOC:dph", "GOC:jid", "GOC:tb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "formation of an anatomical structure involved in morphogenesis",
+          "xrefs" : [ "GOC:dph", "GOC:tb" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that, for example, the formation of a pseudopod in an amoeba would not be considered formation involved in morphogenesis because it would not be thought of as the formation of an anatomical structure that was part of the shaping of the amoeba during its development. The formation of an axon from a neuron would be considered the formation of an anatomical structure involved in morphogenesis because it contributes to the creation of the form of the neuron in a developmental sense."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "anatomical structure formation involved in morphogenesis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0001071",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003700"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0040007",
+      "meta" : {
+        "definition" : {
+          "val" : "The increase in size or mass of an entire organism, a part of an organism or a cell.",
+          "xrefs" : [ "GOC:bf", "GOC:ma" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "growth pattern",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "non-developmental growth",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0048590"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "See also the biological process term 'cell growth ; GO:0016049'."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "growth"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008150",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process specifically pertinent to the functioning of integrated living units: cells, tissues, organs, and organisms. A process is a collection of molecular events with a defined beginning and end.",
+          "xrefs" : [ "GOC:go_curators", "GOC:isa_complete" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Biological_process"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single organism process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "physiological process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single-organism process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "biological process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0000004"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007582"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044699"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2012-09-19T15:05:24Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that, in addition to forming the root of the biological process ontology, this term is recommended for use for the annotation of gene products whose biological process is unknown. Note that when this term is used for annotation, it indicates that no information was available about the biological process of the gene product annotated as of the date the annotation was made; the evidence code ND, no data, is used to indicate this."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "janelomax"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "biological_process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0072519",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0044403"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006091",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways resulting in the formation of precursor metabolites, substances from which energy is derived, and any process involved in the liberation of energy from these substances.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics" ],
+        "synonyms" : [ {
+          "pred" : "hasBroadSynonym",
+          "val" : "energy pathways",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "metabolic energy generation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "intermediary metabolism",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "generation of precursor metabolites and energy"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+      "type" : "PROPERTY",
+      "lbl" : "has_obo_namespace"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044723",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005975"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion",
+      "type" : "PROPERTY",
+      "lbl" : "has_obo_format_version"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0019952",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0000003"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030198",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of an extracellular matrix.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "extracellular matrix organization and biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "extracellular matrix organisation",
+          "xrefs" : [ "GOC:curators" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "extracellular matrix organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003700",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with a specific DNA sequence (sometimes referred to as a motif) within the regulatory region of a gene in order to modulate transcription.",
+          "xrefs" : [ "GOC:curators", "GOC:txnOH" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "nucleic acid binding transcription factor activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "sequence-specific DNA binding transcription factor activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "transcription factor activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "kchris"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0001071"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2010-10-21T04:37:54Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0000130"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "DNA binding transcription factor activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006416",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006412"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006899",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016192"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006412",
+      "meta" : {
+        "definition" : {
+          "val" : "The cellular metabolic process in which a protein is formed, using the sequence of a mature mRNA or circRNA molecule to specify the sequence of amino acids in a polypeptide chain. Translation is mediated by the ribosome, and begins with the formation of a ternary complex between aminoacylated initiator methionine tRNA, GTP, and initiation factor 2, which subsequently associates with the small subunit of the ribosome and an mRNA or circRNA. Translation ends with the release of a polypeptide chain from the ribosome.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_95535"
+        }, {
+          "val" : "Reactome:REACT_101045"
+        }, {
+          "val" : "Wikipedia:Translation_(genetics)"
+        }, {
+          "val" : "Reactome:REACT_79784"
+        }, {
+          "val" : "Reactome:REACT_100851"
+        }, {
+          "val" : "Reactome:REACT_96394"
+        }, {
+          "val" : "Reactome:REACT_100338"
+        }, {
+          "val" : "Reactome:REACT_83429"
+        }, {
+          "val" : "Reactome:REACT_101324"
+        }, {
+          "val" : "Reactome:REACT_81833"
+        }, {
+          "val" : "Reactome:REACT_29980"
+        }, {
+          "val" : "Reactome:REACT_83530"
+        }, {
+          "val" : "Reactome:REACT_103420"
+        }, {
+          "val" : "Reactome:REACT_1014"
+        }, {
+          "val" : "Reactome:REACT_77710"
+        }, {
+          "val" : "Reactome:REACT_105544"
+        }, {
+          "val" : "Reactome:REACT_82171"
+        }, {
+          "val" : "Reactome:REACT_86996"
+        }, {
+          "val" : "Reactome:REACT_81734"
+        }, {
+          "val" : "Reactome:REACT_33559"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "protein anabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein synthesis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein translation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein biosynthetic process",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein formation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "protein biosynthesis",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0006416"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0043037"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0006453"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "translation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Metagenomics GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0040011",
+      "meta" : {
+        "definition" : {
+          "val" : "Self-propelled movement of a cell or organism from one location to another.",
+          "xrefs" : [ "GOC:dgh" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "locomotion"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007067",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0000278"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009370",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0004871"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008283",
+      "meta" : {
+        "definition" : {
+          "val" : "The multiplication or reproduction of cells, resulting in the expansion of a cell population.",
+          "xrefs" : [ "GOC:mah", "GOC:mb" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "This term was moved out from being a child of 'cellular process' because it is a cell population-level process, and cellular processes are restricted to those processes that involve individual cells. Also note that this term is intended to be used for the proliferation of cells within a multicellular organism, not for the expansion of a population of single-celled organisms."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell proliferation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "PIR GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0019843",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with ribosomal RNA.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "rRNA binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009369",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0004871"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/BFO_0000066",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "BFO:0000066"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "occurs_in"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "occurs in"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002091",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002091"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "starts_during"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "starts_during"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002092",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002092"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "happens_during"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "happens_during"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/RO_0002093",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "RO:0002093"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#shorthand",
+          "val" : "ends_during"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "external"
+        } ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "ends_during"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005777",
+      "meta" : {
+        "definition" : {
+          "val" : "A small organelle enclosed by a single membrane, and found in most eukaryotic cells. Contains peroxidases and other enzymes involved in a variety of metabolic processes including free radical detoxification, lipid catabolism and biosynthesis, and hydrogen peroxide metabolism.",
+          "xrefs" : [ "GOC:pm", "PMID:9302272", "UniProtKB-KW:KW-0576" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao499555322"
+        }, {
+          "val" : "Wikipedia:Peroxisome"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "peroxisomal",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "peroxisome vesicle",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0019818"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "peroxisome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005654",
+      "meta" : {
+        "definition" : {
+          "val" : "That part of the nuclear content other than the chromosomes or the nucleolus.",
+          "xrefs" : [ "GOC:ma", "ISBN:0124325653" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao661522542"
+        }, {
+          "val" : "Wikipedia:Nucleoplasm"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nucleoplasm"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005773",
+      "meta" : {
+        "definition" : {
+          "val" : "A closed structure, found only in eukaryotic cells, that is completely surrounded by unit membrane and contains liquid material. Cells contain one or several vacuoles, that may have different functions from each other. Vacuoles have a diverse array of functions. They can act as a storage organelle for nutrients or waste products, as a degradative compartment, as a cost-effective way of increasing cell size, and as a homeostatic regulator controlling both turgor pressure and pH of the cytosol.",
+          "xrefs" : [ "GOC:mtg_sensu", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Vacuole"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "vacuolar carboxypeptidase Y",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "vacuole"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007155",
+      "meta" : {
+        "definition" : {
+          "val" : "The attachment of a cell, either to another cell or to an underlying substrate such as the extracellular matrix, via cell adhesion molecules.",
+          "xrefs" : [ "GOC:hb", "GOC:pf" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cell_adhesion"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cell adhesion molecule activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "single organism cell adhesion",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0098602"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "davidos"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2014-04-15T15:59:10Z"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell adhesion"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007034",
+      "meta" : {
+        "definition" : {
+          "val" : "The directed movement of substances into, out of or within a vacuole.",
+          "xrefs" : [ "GOC:ai" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "vacuolar transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0019818",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005777"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Candida GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008372",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005575"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_goa",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "GOA and proteome slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016301",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the transfer of a phosphate group, usually from ATP, to a substrate molecule.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_85751"
+        }, {
+          "val" : "Reactome:REACT_29277"
+        }, {
+          "val" : "Reactome:REACT_28824"
+        }, {
+          "val" : "Reactome:REACT_101303"
+        }, {
+          "val" : "Reactome:REACT_34222"
+        }, {
+          "val" : "Reactome:REACT_96968"
+        }, {
+          "val" : "Reactome:REACT_79255"
+        }, {
+          "val" : "Reactome:REACT_115358"
+        }, {
+          "val" : "Reactome:REACT_112298"
+        }, {
+          "val" : "Reactome:REACT_77231"
+        }, {
+          "val" : "Reactome:REACT_99207"
+        }, {
+          "val" : "Reactome:REACT_90426"
+        }, {
+          "val" : "Reactome:REACT_114771"
+        }, {
+          "val" : "Reactome:REACT_100636"
+        }, {
+          "val" : "Reactome:REACT_88871"
+        }, {
+          "val" : "Reactome:REACT_83279"
+        }, {
+          "val" : "Reactome:REACT_106159"
+        }, {
+          "val" : "Reactome:REACT_96218"
+        }, {
+          "val" : "Reactome:REACT_94298"
+        }, {
+          "val" : "Reactome:REACT_6353"
+        }, {
+          "val" : "Reactome:REACT_33532"
+        }, {
+          "val" : "Reactome:REACT_89988"
+        }, {
+          "val" : "Reactome:REACT_83436"
+        }, {
+          "val" : "Reactome:REACT_31639"
+        }, {
+          "val" : "Reactome:REACT_104044"
+        }, {
+          "val" : "Reactome:REACT_85379"
+        }, {
+          "val" : "Reactome:REACT_106225"
+        }, {
+          "val" : "Reactome:REACT_107310"
+        }, {
+          "val" : "Reactome:REACT_98741"
+        }, {
+          "val" : "Reactome:REACT_118229"
+        }, {
+          "val" : "Reactome:REACT_79220"
+        }, {
+          "val" : "Reactome:REACT_114461"
+        }, {
+          "val" : "Reactome:REACT_96483"
+        }, {
+          "val" : "Reactome:REACT_80617"
+        }, {
+          "val" : "Reactome:REACT_100159"
+        }, {
+          "val" : "Reactome:REACT_110774"
+        }, {
+          "val" : "Reactome:REACT_115472"
+        }, {
+          "val" : "Reactome:REACT_77911"
+        }, {
+          "val" : "Reactome:REACT_105971"
+        }, {
+          "val" : "Reactome:REACT_97193"
+        }, {
+          "val" : "Reactome:REACT_101667"
+        }, {
+          "val" : "Reactome:REACT_102817"
+        }, {
+          "val" : "Reactome:REACT_92126"
+        }, {
+          "val" : "Reactome:REACT_93221"
+        }, {
+          "val" : "Reactome:REACT_88440"
+        }, {
+          "val" : "Reactome:REACT_81458"
+        }, {
+          "val" : "Reactome:REACT_94784"
+        }, {
+          "val" : "Reactome:REACT_88055"
+        }, {
+          "val" : "Reactome:REACT_78533"
+        }, {
+          "val" : "Reactome:REACT_108871"
+        }, {
+          "val" : "Reactome:REACT_100495"
+        }, {
+          "val" : "Reactome:REACT_99929"
+        }, {
+          "val" : "Reactome:REACT_85449"
+        }, {
+          "val" : "Reactome:REACT_108776"
+        }, {
+          "val" : "Reactome:REACT_86261"
+        }, {
+          "val" : "Reactome:REACT_98663"
+        }, {
+          "val" : "Reactome:REACT_78451"
+        }, {
+          "val" : "Reactome:REACT_545"
+        }, {
+          "val" : "Reactome:REACT_112709"
+        }, {
+          "val" : "Reactome:REACT_30345"
+        }, {
+          "val" : "Reactome:REACT_110296"
+        }, {
+          "val" : "Reactome:REACT_114280"
+        }, {
+          "val" : "Reactome:REACT_28054"
+        }, {
+          "val" : "Reactome:REACT_95163"
+        }, {
+          "val" : "Reactome:REACT_103359"
+        }, {
+          "val" : "Reactome:REACT_89122"
+        }, {
+          "val" : "Reactome:REACT_81218"
+        }, {
+          "val" : "Reactome:REACT_92736"
+        }, {
+          "val" : "Reactome:REACT_106383"
+        }, {
+          "val" : "Reactome:REACT_29689"
+        }, {
+          "val" : "Reactome:REACT_97667"
+        }, {
+          "val" : "Reactome:REACT_34516"
+        }, {
+          "val" : "Reactome:REACT_113022"
+        }, {
+          "val" : "Reactome:REACT_6883"
+        }, {
+          "val" : "Reactome:REACT_79182"
+        }, {
+          "val" : "Reactome:REACT_103727"
+        }, {
+          "val" : "Reactome:REACT_6342"
+        }, {
+          "val" : "Reactome:REACT_414"
+        }, {
+          "val" : "Reactome:REACT_88564"
+        }, {
+          "val" : "Reactome:REACT_33840"
+        }, {
+          "val" : "Reactome:REACT_101596"
+        }, {
+          "val" : "Reactome:REACT_77897"
+        }, {
+          "val" : "Reactome:REACT_85009"
+        }, {
+          "val" : "Reactome:REACT_91643"
+        }, {
+          "val" : "Reactome:REACT_83110"
+        }, {
+          "val" : "Reactome:REACT_22099"
+        }, {
+          "val" : "Reactome:REACT_96524"
+        }, {
+          "val" : "Reactome:REACT_82261"
+        }, {
+          "val" : "Reactome:REACT_77654"
+        }, {
+          "val" : "Reactome:REACT_98913"
+        }, {
+          "val" : "Reactome:REACT_98434"
+        }, {
+          "val" : "Reactome:REACT_58131"
+        }, {
+          "val" : "Reactome:REACT_105274"
+        }, {
+          "val" : "Reactome:REACT_88430"
+        }, {
+          "val" : "Reactome:REACT_82456"
+        }, {
+          "val" : "Reactome:REACT_96102"
+        }, {
+          "val" : "Reactome:REACT_1279"
+        }, {
+          "val" : "Reactome:REACT_105700"
+        }, {
+          "val" : "Reactome:REACT_99266"
+        }, {
+          "val" : "Reactome:REACT_97577"
+        }, {
+          "val" : "Reactome:REACT_107247"
+        }, {
+          "val" : "Reactome:REACT_87679"
+        }, {
+          "val" : "Reactome:REACT_100305"
+        }, {
+          "val" : "Reactome:REACT_9067"
+        }, {
+          "val" : "Reactome:REACT_114906"
+        }, {
+          "val" : "Reactome:REACT_93706"
+        }, {
+          "val" : "Reactome:REACT_90917"
+        }, {
+          "val" : "Reactome:REACT_78226"
+        }, {
+          "val" : "Reactome:REACT_100078"
+        }, {
+          "val" : "Reactome:REACT_99302"
+        }, {
+          "val" : "Reactome:REACT_6170"
+        }, {
+          "val" : "Reactome:REACT_80591"
+        }, {
+          "val" : "Reactome:REACT_88928"
+        }, {
+          "val" : "Reactome:REACT_113990"
+        }, {
+          "val" : "Reactome:REACT_33519"
+        }, {
+          "val" : "Reactome:REACT_98378"
+        }, {
+          "val" : "Reactome:REACT_91470"
+        }, {
+          "val" : "Reactome:REACT_85699"
+        }, {
+          "val" : "Reactome:REACT_105254"
+        }, {
+          "val" : "Reactome:REACT_87485"
+        }, {
+          "val" : "Reactome:REACT_97905"
+        }, {
+          "val" : "Reactome:REACT_86061"
+        }, {
+          "val" : "Reactome:REACT_32150"
+        }, {
+          "val" : "Reactome:REACT_32145"
+        }, {
+          "val" : "Reactome:REACT_30700"
+        }, {
+          "val" : "Reactome:REACT_32079"
+        }, {
+          "val" : "Reactome:REACT_90290"
+        }, {
+          "val" : "Reactome:REACT_84273"
+        }, {
+          "val" : "Reactome:REACT_114207"
+        }, {
+          "val" : "Reactome:REACT_102330"
+        }, {
+          "val" : "Reactome:REACT_30020"
+        }, {
+          "val" : "Reactome:REACT_84560"
+        }, {
+          "val" : "Reactome:REACT_104022"
+        }, {
+          "val" : "Reactome:REACT_29451"
+        }, {
+          "val" : "Reactome:REACT_78087"
+        }, {
+          "val" : "Reactome:REACT_84405"
+        }, {
+          "val" : "Reactome:REACT_112075"
+        }, {
+          "val" : "Reactome:REACT_106505"
+        }, {
+          "val" : "Reactome:REACT_6297"
+        }, {
+          "val" : "Reactome:REACT_99141"
+        }, {
+          "val" : "Reactome:REACT_86952"
+        }, {
+          "val" : "Reactome:REACT_82270"
+        }, {
+          "val" : "Reactome:REACT_94151"
+        }, {
+          "val" : "Reactome:REACT_86372"
+        }, {
+          "val" : "Reactome:REACT_104644"
+        }, {
+          "val" : "Reactome:REACT_103291"
+        }, {
+          "val" : "Reactome:REACT_102711"
+        }, {
+          "val" : "Reactome:REACT_77040"
+        }, {
+          "val" : "Reactome:REACT_80699"
+        }, {
+          "val" : "Reactome:REACT_106075"
+        }, {
+          "val" : "Reactome:REACT_29396"
+        }, {
+          "val" : "Reactome:REACT_31868"
+        }, {
+          "val" : "Reactome:REACT_28746"
+        }, {
+          "val" : "Reactome:REACT_96656"
+        }, {
+          "val" : "Reactome:REACT_19312"
+        }, {
+          "val" : "Reactome:REACT_93366"
+        }, {
+          "val" : "Reactome:REACT_113244"
+        }, {
+          "val" : "Reactome:REACT_78427"
+        }, {
+          "val" : "Reactome:REACT_92033"
+        }, {
+          "val" : "Reactome:REACT_34788"
+        }, {
+          "val" : "Reactome:REACT_98050"
+        }, {
+          "val" : "Reactome:REACT_91157"
+        }, {
+          "val" : "Reactome:REACT_81027"
+        }, {
+          "val" : "Reactome:REACT_30490"
+        }, {
+          "val" : "Reactome:REACT_29168"
+        }, {
+          "val" : "Reactome:REACT_99231"
+        }, {
+          "val" : "Reactome:REACT_90227"
+        }, {
+          "val" : "Reactome:REACT_20640"
+        }, {
+          "val" : "Reactome:REACT_77074"
+        }, {
+          "val" : "Reactome:REACT_86800"
+        }, {
+          "val" : "Reactome:REACT_1116"
+        }, {
+          "val" : "Reactome:REACT_106567"
+        }, {
+          "val" : "Reactome:REACT_99025"
+        }, {
+          "val" : "Reactome:REACT_87424"
+        }, {
+          "val" : "Reactome:REACT_102915"
+        }, {
+          "val" : "Reactome:REACT_87523"
+        }, {
+          "val" : "Reactome:REACT_93346"
+        }, {
+          "val" : "Reactome:REACT_110679"
+        }, {
+          "val" : "Reactome:REACT_30679"
+        }, {
+          "val" : "Reactome:REACT_95437"
+        }, {
+          "val" : "Reactome:REACT_96200"
+        }, {
+          "val" : "Reactome:REACT_88298"
+        }, {
+          "val" : "Reactome:REACT_105664"
+        }, {
+          "val" : "Reactome:REACT_86277"
+        }, {
+          "val" : "Reactome:REACT_31571"
+        }, {
+          "val" : "Reactome:REACT_109117"
+        }, {
+          "val" : "Reactome:REACT_30496"
+        }, {
+          "val" : "Reactome:REACT_82824"
+        }, {
+          "val" : "Reactome:REACT_106599"
+        }, {
+          "val" : "Reactome:REACT_86422"
+        }, {
+          "val" : "Reactome:REACT_91541"
+        }, {
+          "val" : "Reactome:REACT_31536"
+        }, {
+          "val" : "Reactome:REACT_86014"
+        }, {
+          "val" : "Reactome:REACT_98443"
+        }, {
+          "val" : "Reactome:REACT_96039"
+        }, {
+          "val" : "Reactome:REACT_82361"
+        }, {
+          "val" : "Reactome:REACT_1420"
+        }, {
+          "val" : "Reactome:REACT_109769"
+        }, {
+          "val" : "Reactome:REACT_112545"
+        }, {
+          "val" : "Reactome:REACT_113894"
+        }, {
+          "val" : "Reactome:REACT_113227"
+        }, {
+          "val" : "Reactome:REACT_79686"
+        }, {
+          "val" : "Reactome:REACT_102729"
+        }, {
+          "val" : "Reactome:REACT_112324"
+        }, {
+          "val" : "Reactome:REACT_98493"
+        }, {
+          "val" : "Reactome:REACT_559"
+        }, {
+          "val" : "Reactome:REACT_79012"
+        }, {
+          "val" : "Reactome:REACT_102607"
+        }, {
+          "val" : "Reactome:REACT_109065"
+        }, {
+          "val" : "Reactome:REACT_32009"
+        }, {
+          "val" : "Reactome:REACT_79087"
+        }, {
+          "val" : "Reactome:REACT_23976"
+        }, {
+          "val" : "Reactome:REACT_31915"
+        }, {
+          "val" : "Reactome:REACT_96468"
+        }, {
+          "val" : "Reactome:REACT_87391"
+        }, {
+          "val" : "Reactome:REACT_169"
+        }, {
+          "val" : "Reactome:REACT_106738"
+        }, {
+          "val" : "Reactome:REACT_98066"
+        }, {
+          "val" : "Reactome:REACT_937"
+        }, {
+          "val" : "Reactome:REACT_93746"
+        }, {
+          "val" : "Reactome:REACT_31273"
+        }, {
+          "val" : "Reactome:REACT_113051"
+        }, {
+          "val" : "Reactome:REACT_84348"
+        }, {
+          "val" : "Reactome:REACT_105589"
+        }, {
+          "val" : "Reactome:REACT_103468"
+        }, {
+          "val" : "Reactome:REACT_91760"
+        }, {
+          "val" : "Reactome:REACT_87650"
+        }, {
+          "val" : "Reactome:REACT_2111"
+        }, {
+          "val" : "Reactome:REACT_82728"
+        }, {
+          "val" : "Reactome:REACT_1782"
+        }, {
+          "val" : "Reactome:REACT_9057"
+        }, {
+          "val" : "Reactome:REACT_1481"
+        }, {
+          "val" : "Reactome:REACT_114227"
+        }, {
+          "val" : "Reactome:REACT_1981"
+        }, {
+          "val" : "Reactome:REACT_1808"
+        }, {
+          "val" : "Reactome:REACT_96758"
+        }, {
+          "val" : "Reactome:REACT_107849"
+        }, {
+          "val" : "Reactome:REACT_6861"
+        }, {
+          "val" : "Reactome:REACT_6327"
+        }, {
+          "val" : "Reactome:REACT_80218"
+        }, {
+          "val" : "Reactome:REACT_82037"
+        }, {
+          "val" : "Reactome:REACT_29588"
+        }, {
+          "val" : "Reactome:REACT_87222"
+        }, {
+          "val" : "Reactome:REACT_98847"
+        }, {
+          "val" : "Reactome:REACT_115521"
+        }, {
+          "val" : "Reactome:REACT_29694"
+        }, {
+          "val" : "Reactome:REACT_9955"
+        }, {
+          "val" : "Reactome:REACT_83476"
+        }, {
+          "val" : "Reactome:REACT_92852"
+        }, {
+          "val" : "Reactome:REACT_83239"
+        }, {
+          "val" : "Reactome:REACT_114198"
+        }, {
+          "val" : "Reactome:REACT_77660"
+        }, {
+          "val" : "Reactome:REACT_31519"
+        }, {
+          "val" : "Reactome:REACT_101841"
+        }, {
+          "val" : "Reactome:REACT_115527"
+        }, {
+          "val" : "Reactome:REACT_29029"
+        }, {
+          "val" : "Reactome:REACT_105503"
+        }, {
+          "val" : "Reactome:REACT_104822"
+        }, {
+          "val" : "Reactome:REACT_88548"
+        }, {
+          "val" : "Reactome:REACT_92247"
+        }, {
+          "val" : "Reactome:REACT_112633"
+        }, {
+          "val" : "Reactome:REACT_96"
+        }, {
+          "val" : "Reactome:REACT_79208"
+        }, {
+          "val" : "Reactome:REACT_86533"
+        }, {
+          "val" : "Reactome:REACT_2009"
+        }, {
+          "val" : "Reactome:REACT_107732"
+        }, {
+          "val" : "Reactome:REACT_101862"
+        }, {
+          "val" : "Reactome:REACT_6316"
+        }, {
+          "val" : "Reactome:REACT_87880"
+        }, {
+          "val" : "Reactome:REACT_81652"
+        }, {
+          "val" : "Reactome:REACT_78121"
+        }, {
+          "val" : "Reactome:REACT_77450"
+        }, {
+          "val" : "Reactome:REACT_93615"
+        }, {
+          "val" : "Reactome:REACT_112846"
+        }, {
+          "val" : "Reactome:REACT_128"
+        }, {
+          "val" : "Reactome:REACT_1603"
+        }, {
+          "val" : "Reactome:REACT_30948"
+        }, {
+          "val" : "Reactome:REACT_89001"
+        }, {
+          "val" : "Reactome:REACT_110947"
+        }, {
+          "val" : "Reactome:REACT_82927"
+        }, {
+          "val" : "Reactome:REACT_96208"
+        }, {
+          "val" : "Reactome:REACT_111930"
+        }, {
+          "val" : "Reactome:REACT_86867"
+        }, {
+          "val" : "Reactome:REACT_78539"
+        }, {
+          "val" : "Reactome:REACT_94562"
+        }, {
+          "val" : "Reactome:REACT_31081"
+        }, {
+          "val" : "Reactome:REACT_96877"
+        }, {
+          "val" : "Reactome:REACT_34514"
+        }, {
+          "val" : "Reactome:REACT_80700"
+        }, {
+          "val" : "Reactome:REACT_108002"
+        }, {
+          "val" : "Reactome:REACT_114553"
+        }, {
+          "val" : "Reactome:REACT_85720"
+        }, {
+          "val" : "Reactome:REACT_98779"
+        }, {
+          "val" : "Reactome:REACT_79573"
+        }, {
+          "val" : "Reactome:REACT_110382"
+        }, {
+          "val" : "Reactome:REACT_80632"
+        }, {
+          "val" : "Reactome:REACT_32374"
+        }, {
+          "val" : "Reactome:REACT_80909"
+        }, {
+          "val" : "Reactome:REACT_100465"
+        }, {
+          "val" : "Reactome:REACT_88766"
+        }, {
+          "val" : "Reactome:REACT_77397"
+        }, {
+          "val" : "Reactome:REACT_113527"
+        }, {
+          "val" : "Reactome:REACT_33692"
+        }, {
+          "val" : "Reactome:REACT_104209"
+        }, {
+          "val" : "Reactome:REACT_81647"
+        }, {
+          "val" : "Reactome:REACT_33928"
+        }, {
+          "val" : "Reactome:REACT_100311"
+        }, {
+          "val" : "Reactome:REACT_81439"
+        }, {
+          "val" : "Reactome:REACT_98213"
+        }, {
+          "val" : "Reactome:REACT_108578"
+        }, {
+          "val" : "Reactome:REACT_29284"
+        }, {
+          "val" : "Reactome:REACT_88091"
+        }, {
+          "val" : "Reactome:REACT_107424"
+        }, {
+          "val" : "Reactome:REACT_85812"
+        }, {
+          "val" : "Reactome:REACT_89879"
+        }, {
+          "val" : "Reactome:REACT_106324"
+        }, {
+          "val" : "Reactome:REACT_102475"
+        }, {
+          "val" : "Reactome:REACT_33979"
+        }, {
+          "val" : "Reactome:REACT_30116"
+        }, {
+          "val" : "Reactome:REACT_78450"
+        }, {
+          "val" : "Reactome:REACT_94615"
+        }, {
+          "val" : "Reactome:REACT_91050"
+        }, {
+          "val" : "Reactome:REACT_87149"
+        }, {
+          "val" : "Reactome:REACT_98971"
+        }, {
+          "val" : "Reactome:REACT_103327"
+        }, {
+          "val" : "Reactome:REACT_88516"
+        }, {
+          "val" : "Reactome:REACT_79125"
+        }, {
+          "val" : "Reactome:REACT_81727"
+        }, {
+          "val" : "Reactome:REACT_108096"
+        }, {
+          "val" : "Reactome:REACT_264"
+        }, {
+          "val" : "Reactome:REACT_77234"
+        }, {
+          "val" : "Reactome:REACT_29914"
+        }, {
+          "val" : "Reactome:REACT_114255"
+        }, {
+          "val" : "Reactome:REACT_99595"
+        }, {
+          "val" : "Reactome:REACT_107102"
+        }, {
+          "val" : "Reactome:REACT_112722"
+        }, {
+          "val" : "Reactome:REACT_32358"
+        }, {
+          "val" : "Reactome:REACT_104323"
+        }, {
+          "val" : "Reactome:REACT_28480"
+        }, {
+          "val" : "Reactome:REACT_96356"
+        }, {
+          "val" : "Reactome:REACT_93166"
+        }, {
+          "val" : "Reactome:REACT_81693"
+        }, {
+          "val" : "Reactome:REACT_112948"
+        }, {
+          "val" : "Reactome:REACT_88590"
+        }, {
+          "val" : "Reactome:REACT_111171"
+        }, {
+          "val" : "Reactome:REACT_96500"
+        }, {
+          "val" : "Reactome:REACT_13581"
+        }, {
+          "val" : "Reactome:REACT_95504"
+        }, {
+          "val" : "Reactome:REACT_108362"
+        }, {
+          "val" : "Reactome:REACT_34111"
+        }, {
+          "val" : "Reactome:REACT_28743"
+        }, {
+          "val" : "Reactome:REACT_81715"
+        }, {
+          "val" : "Reactome:REACT_1944"
+        }, {
+          "val" : "Reactome:REACT_91263"
+        }, {
+          "val" : "Reactome:REACT_91382"
+        }, {
+          "val" : "Reactome:REACT_109331"
+        }, {
+          "val" : "Reactome:REACT_32845"
+        }, {
+          "val" : "Reactome:REACT_88665"
+        }, {
+          "val" : "Reactome:REACT_114160"
+        }, {
+          "val" : "Reactome:REACT_81590"
+        }, {
+          "val" : "Reactome:REACT_9007"
+        }, {
+          "val" : "Reactome:REACT_96899"
+        }, {
+          "val" : "Reactome:REACT_1930"
+        }, {
+          "val" : "Reactome:REACT_20543"
+        }, {
+          "val" : "Reactome:REACT_1888"
+        }, {
+          "val" : "Reactome:REACT_102887"
+        }, {
+          "val" : "Reactome:REACT_13817"
+        }, {
+          "val" : "Reactome:REACT_87534"
+        }, {
+          "val" : "Reactome:REACT_79709"
+        }, {
+          "val" : "Reactome:REACT_110254"
+        }, {
+          "val" : "Reactome:REACT_98109"
+        }, {
+          "val" : "Reactome:REACT_1185"
+        }, {
+          "val" : "Reactome:REACT_91937"
+        }, {
+          "val" : "Reactome:REACT_86092"
+        }, {
+          "val" : "Reactome:REACT_80860"
+        }, {
+          "val" : "Reactome:REACT_85017"
+        }, {
+          "val" : "Reactome:REACT_6778"
+        }, {
+          "val" : "Reactome:REACT_1326"
+        }, {
+          "val" : "Reactome:REACT_100637"
+        }, {
+          "val" : "Reactome:REACT_109549"
+        }, {
+          "val" : "Reactome:REACT_109264"
+        }, {
+          "val" : "Reactome:REACT_109045"
+        }, {
+          "val" : "Reactome:REACT_78696"
+        }, {
+          "val" : "Reactome:REACT_110775"
+        }, {
+          "val" : "Reactome:REACT_90449"
+        }, {
+          "val" : "Reactome:REACT_81616"
+        }, {
+          "val" : "Reactome:REACT_92108"
+        }, {
+          "val" : "Reactome:REACT_114624"
+        }, {
+          "val" : "Reactome:REACT_108520"
+        }, {
+          "val" : "Reactome:REACT_988"
+        }, {
+          "val" : "Reactome:REACT_114323"
+        }, {
+          "val" : "Reactome:REACT_78901"
+        }, {
+          "val" : "Reactome:REACT_94017"
+        }, {
+          "val" : "Reactome:REACT_98996"
+        }, {
+          "val" : "Reactome:REACT_92929"
+        }, {
+          "val" : "Reactome:REACT_101543"
+        }, {
+          "val" : "Reactome:REACT_77326"
+        }, {
+          "val" : "Reactome:REACT_31293"
+        }, {
+          "val" : "Reactome:REACT_98395"
+        }, {
+          "val" : "Reactome:REACT_92889"
+        }, {
+          "val" : "Reactome:REACT_30985"
+        }, {
+          "val" : "Reactome:REACT_302"
+        }, {
+          "val" : "Reactome:REACT_86252"
+        }, {
+          "val" : "Reactome:REACT_113929"
+        }, {
+          "val" : "Reactome:REACT_80714"
+        }, {
+          "val" : "Reactome:REACT_80853"
+        }, {
+          "val" : "Reactome:REACT_106186"
+        }, {
+          "val" : "Reactome:REACT_93414"
+        }, {
+          "val" : "Reactome:REACT_83178"
+        }, {
+          "val" : "Reactome:REACT_28681"
+        }, {
+          "val" : "Reactome:REACT_94397"
+        }, {
+          "val" : "Reactome:REACT_83006"
+        }, {
+          "val" : "Reactome:REACT_97218"
+        }, {
+          "val" : "Reactome:REACT_1382"
+        }, {
+          "val" : "Reactome:REACT_30070"
+        }, {
+          "val" : "Reactome:REACT_83533"
+        }, {
+          "val" : "Reactome:REACT_43"
+        }, {
+          "val" : "Reactome:REACT_98560"
+        }, {
+          "val" : "Reactome:REACT_85836"
+        }, {
+          "val" : "Reactome:REACT_78281"
+        }, {
+          "val" : "Reactome:REACT_83709"
+        }, {
+          "val" : "Reactome:REACT_907"
+        }, {
+          "val" : "Reactome:REACT_77550"
+        }, {
+          "val" : "Reactome:REACT_93878"
+        }, {
+          "val" : "Reactome:REACT_85066"
+        }, {
+          "val" : "Reactome:REACT_99560"
+        }, {
+          "val" : "Reactome:REACT_2119"
+        }, {
+          "val" : "Reactome:REACT_89427"
+        }, {
+          "val" : "Reactome:REACT_94258"
+        }, {
+          "val" : "Reactome:REACT_83727"
+        }, {
+          "val" : "Reactome:REACT_32565"
+        }, {
+          "val" : "Reactome:REACT_845"
+        }, {
+          "val" : "Reactome:REACT_88374"
+        }, {
+          "val" : "Reactome:REACT_1657"
+        }, {
+          "val" : "Reactome:REACT_99158"
+        }, {
+          "val" : "Reactome:REACT_102908"
+        }, {
+          "val" : "Reactome:REACT_84082"
+        }, {
+          "val" : "Reactome:REACT_77834"
+        }, {
+          "val" : "Reactome:REACT_96797"
+        }, {
+          "val" : "Reactome:REACT_93124"
+        }, {
+          "val" : "Reactome:REACT_384"
+        }, {
+          "val" : "Reactome:REACT_95461"
+        }, {
+          "val" : "Reactome:REACT_82115"
+        }, {
+          "val" : "Reactome:REACT_91684"
+        }, {
+          "val" : "Reactome:REACT_94113"
+        }, {
+          "val" : "Reactome:REACT_112214"
+        }, {
+          "val" : "Reactome:REACT_107854"
+        }, {
+          "val" : "Reactome:REACT_115135"
+        }, {
+          "val" : "Reactome:REACT_90167"
+        }, {
+          "val" : "Reactome:REACT_90562"
+        }, {
+          "val" : "Reactome:REACT_33003"
+        }, {
+          "val" : "Reactome:REACT_188"
+        }, {
+          "val" : "Reactome:REACT_83696"
+        }, {
+          "val" : "Reactome:REACT_101914"
+        }, {
+          "val" : "Reactome:REACT_80239"
+        }, {
+          "val" : "Reactome:REACT_1756"
+        }, {
+          "val" : "Reactome:REACT_112413"
+        }, {
+          "val" : "Reactome:REACT_92915"
+        }, {
+          "val" : "Reactome:REACT_109197"
+        }, {
+          "val" : "Reactome:REACT_83579"
+        }, {
+          "val" : "Reactome:REACT_32271"
+        }, {
+          "val" : "Reactome:REACT_29300"
+        }, {
+          "val" : "Reactome:REACT_34285"
+        }, {
+          "val" : "Reactome:REACT_91156"
+        }, {
+          "val" : "Reactome:REACT_88486"
+        }, {
+          "val" : "Reactome:REACT_84080"
+        }, {
+          "val" : "Reactome:REACT_31227"
+        }, {
+          "val" : "Reactome:REACT_1680"
+        }, {
+          "val" : "Reactome:REACT_92148"
+        }, {
+          "val" : "Reactome:REACT_102090"
+        }, {
+          "val" : "Reactome:REACT_77443"
+        }, {
+          "val" : "Reactome:REACT_20583"
+        }, {
+          "val" : "Reactome:REACT_13820"
+        }, {
+          "val" : "Reactome:REACT_89366"
+        }, {
+          "val" : "Reactome:REACT_20562"
+        }, {
+          "val" : "Reactome:REACT_95089"
+        }, {
+          "val" : "Reactome:REACT_100519"
+        }, {
+          "val" : "Reactome:REACT_103691"
+        }, {
+          "val" : "Reactome:REACT_114319"
+        }, {
+          "val" : "Reactome:REACT_89794"
+        }, {
+          "val" : "Reactome:REACT_88458"
+        }, {
+          "val" : "Reactome:REACT_1517"
+        }, {
+          "val" : "Reactome:REACT_34804"
+        }, {
+          "val" : "Reactome:REACT_6952"
+        }, {
+          "val" : "Reactome:REACT_101170"
+        }, {
+          "val" : "Reactome:REACT_94452"
+        }, {
+          "val" : "Reactome:REACT_77179"
+        }, {
+          "val" : "Reactome:REACT_83671"
+        }, {
+          "val" : "Reactome:REACT_77733"
+        }, {
+          "val" : "Reactome:REACT_31149"
+        }, {
+          "val" : "Reactome:REACT_79694"
+        }, {
+          "val" : "Reactome:REACT_109244"
+        }, {
+          "val" : "Reactome:REACT_105569"
+        }, {
+          "val" : "Reactome:REACT_77615"
+        }, {
+          "val" : "Reactome:REACT_32620"
+        }, {
+          "val" : "Reactome:REACT_79700"
+        }, {
+          "val" : "Reactome:REACT_97458"
+        }, {
+          "val" : "Reactome:REACT_13431"
+        }, {
+          "val" : "Reactome:REACT_90132"
+        }, {
+          "val" : "Reactome:REACT_102154"
+        }, {
+          "val" : "Reactome:REACT_6859"
+        }, {
+          "val" : "Reactome:REACT_91574"
+        }, {
+          "val" : "Reactome:REACT_83979"
+        }, {
+          "val" : "Reactome:REACT_85871"
+        }, {
+          "val" : "Reactome:REACT_92219"
+        }, {
+          "val" : "Reactome:REACT_33080"
+        }, {
+          "val" : "Reactome:REACT_97759"
+        }, {
+          "val" : "Reactome:REACT_1878"
+        }, {
+          "val" : "Reactome:REACT_104386"
+        }, {
+          "val" : "Reactome:REACT_89547"
+        }, {
+          "val" : "Reactome:REACT_78748"
+        }, {
+          "val" : "Reactome:REACT_104523"
+        }, {
+          "val" : "Reactome:REACT_102499"
+        }, {
+          "val" : "Reactome:REACT_100298"
+        }, {
+          "val" : "Reactome:REACT_89769"
+        }, {
+          "val" : "Reactome:REACT_80255"
+        }, {
+          "val" : "Reactome:REACT_78651"
+        }, {
+          "val" : "Reactome:REACT_107787"
+        }, {
+          "val" : "Reactome:REACT_104837"
+        }, {
+          "val" : "Reactome:REACT_77535"
+        }, {
+          "val" : "Reactome:REACT_87593"
+        }, {
+          "val" : "Reactome:REACT_88987"
+        }, {
+          "val" : "Reactome:REACT_29614"
+        }, {
+          "val" : "Reactome:REACT_96461"
+        }, {
+          "val" : "Reactome:REACT_30023"
+        }, {
+          "val" : "Reactome:REACT_93441"
+        }, {
+          "val" : "Reactome:REACT_89026"
+        }, {
+          "val" : "Reactome:REACT_29788"
+        }, {
+          "val" : "Reactome:REACT_94947"
+        }, {
+          "val" : "Reactome:REACT_106722"
+        }, {
+          "val" : "Reactome:REACT_115747"
+        }, {
+          "val" : "Reactome:REACT_98296"
+        }, {
+          "val" : "Reactome:REACT_32956"
+        }, {
+          "val" : "Reactome:REACT_88421"
+        }, {
+          "val" : "Reactome:REACT_33369"
+        }, {
+          "val" : "Reactome:REACT_6178"
+        }, {
+          "val" : "Reactome:REACT_34403"
+        }, {
+          "val" : "Reactome:REACT_90220"
+        }, {
+          "val" : "Reactome:REACT_78556"
+        }, {
+          "val" : "Reactome:REACT_98024"
+        }, {
+          "val" : "Reactome:REACT_81941"
+        }, {
+          "val" : "Reactome:REACT_29410"
+        }, {
+          "val" : "Reactome:REACT_82473"
+        }, {
+          "val" : "Reactome:REACT_104687"
+        }, {
+          "val" : "Reactome:REACT_6234"
+        }, {
+          "val" : "Reactome:REACT_115168"
+        }, {
+          "val" : "Reactome:REACT_106420"
+        }, {
+          "val" : "Reactome:REACT_77606"
+        }, {
+          "val" : "Reactome:REACT_93105"
+        }, {
+          "val" : "Reactome:REACT_91062"
+        }, {
+          "val" : "Reactome:REACT_98176"
+        }, {
+          "val" : "Reactome:REACT_91501"
+        }, {
+          "val" : "Reactome:REACT_80213"
+        }, {
+          "val" : "Reactome:REACT_95769"
+        }, {
+          "val" : "Reactome:REACT_33385"
+        }, {
+          "val" : "Reactome:REACT_6139"
+        }, {
+          "val" : "Reactome:REACT_114233"
+        }, {
+          "val" : "Reactome:REACT_82310"
+        }, {
+          "val" : "Reactome:REACT_31935"
+        }, {
+          "val" : "Reactome:REACT_34607"
+        }, {
+          "val" : "Reactome:REACT_30997"
+        }, {
+          "val" : "Reactome:REACT_115199"
+        }, {
+          "val" : "Reactome:REACT_95155"
+        }, {
+          "val" : "Reactome:REACT_92804"
+        }, {
+          "val" : "Reactome:REACT_97299"
+        }, {
+          "val" : "Reactome:REACT_88025"
+        }, {
+          "val" : "Reactome:REACT_107009"
+        }, {
+          "val" : "Reactome:REACT_28719"
+        }, {
+          "val" : "Reactome:REACT_88668"
+        }, {
+          "val" : "Reactome:REACT_78035"
+        }, {
+          "val" : "Reactome:REACT_83582"
+        }, {
+          "val" : "Reactome:REACT_31290"
+        }, {
+          "val" : "Reactome:REACT_33009"
+        }, {
+          "val" : "Reactome:REACT_98731"
+        }, {
+          "val" : "Reactome:REACT_114522"
+        }, {
+          "val" : "Reactome:REACT_29759"
+        }, {
+          "val" : "Reactome:REACT_76979"
+        }, {
+          "val" : "Reactome:REACT_6948"
+        }, {
+          "val" : "Reactome:REACT_80684"
+        }, {
+          "val" : "Reactome:REACT_34145"
+        }, {
+          "val" : "Reactome:REACT_113435"
+        }, {
+          "val" : "Reactome:REACT_96129"
+        }, {
+          "val" : "Reactome:REACT_96793"
+        }, {
+          "val" : "Reactome:REACT_30836"
+        }, {
+          "val" : "Reactome:REACT_34080"
+        }, {
+          "val" : "Reactome:REACT_114268"
+        }, {
+          "val" : "Reactome:REACT_103989"
+        }, {
+          "val" : "Reactome:REACT_1063"
+        }, {
+          "val" : "Reactome:REACT_98436"
+        }, {
+          "val" : "Reactome:REACT_32906"
+        }, {
+          "val" : "Reactome:REACT_99785"
+        }, {
+          "val" : "Reactome:REACT_109641"
+        }, {
+          "val" : "Reactome:REACT_93149"
+        }, {
+          "val" : "Reactome:REACT_98738"
+        }, {
+          "val" : "Reactome:REACT_106514"
+        }, {
+          "val" : "Reactome:REACT_111124"
+        }, {
+          "val" : "Reactome:REACT_77977"
+        }, {
+          "val" : "Reactome:REACT_32438"
+        }, {
+          "val" : "Reactome:REACT_87121"
+        }, {
+          "val" : "Reactome:REACT_30113"
+        }, {
+          "val" : "Reactome:REACT_84932"
+        }, {
+          "val" : "Reactome:REACT_118462"
+        }, {
+          "val" : "Reactome:REACT_83187"
+        }, {
+          "val" : "Reactome:REACT_82616"
+        }, {
+          "val" : "Reactome:REACT_87298"
+        }, {
+          "val" : "Reactome:REACT_80144"
+        }, {
+          "val" : "Reactome:REACT_118284"
+        }, {
+          "val" : "Reactome:REACT_107243"
+        }, {
+          "val" : "Reactome:REACT_9987"
+        }, {
+          "val" : "Reactome:REACT_28163"
+        }, {
+          "val" : "Reactome:REACT_100073"
+        }, {
+          "val" : "Reactome:REACT_23990"
+        }, {
+          "val" : "Reactome:REACT_110995"
+        }, {
+          "val" : "Reactome:REACT_102322"
+        }, {
+          "val" : "Reactome:REACT_104878"
+        }, {
+          "val" : "Reactome:REACT_101638"
+        }, {
+          "val" : "Reactome:REACT_110351"
+        }, {
+          "val" : "Reactome:REACT_83899"
+        }, {
+          "val" : "Reactome:REACT_203"
+        }, {
+          "val" : "Reactome:REACT_20631"
+        }, {
+          "val" : "Reactome:REACT_112892"
+        }, {
+          "val" : "Reactome:REACT_80689"
+        }, {
+          "val" : "Reactome:REACT_9070"
+        }, {
+          "val" : "Reactome:REACT_94817"
+        }, {
+          "val" : "Reactome:REACT_93440"
+        }, {
+          "val" : "Reactome:REACT_86736"
+        }, {
+          "val" : "Reactome:REACT_80185"
+        }, {
+          "val" : "Reactome:REACT_30938"
+        }, {
+          "val" : "Reactome:REACT_86415"
+        }, {
+          "val" : "Reactome:REACT_87753"
+        }, {
+          "val" : "Reactome:REACT_104730"
+        }, {
+          "val" : "Reactome:REACT_87503"
+        }, {
+          "val" : "Reactome:REACT_89464"
+        }, {
+          "val" : "Reactome:REACT_77928"
+        }, {
+          "val" : "Reactome:REACT_105373"
+        }, {
+          "val" : "Reactome:REACT_114599"
+        }, {
+          "val" : "Reactome:REACT_6912"
+        }, {
+          "val" : "Reactome:REACT_87967"
+        }, {
+          "val" : "Reactome:REACT_92407"
+        }, {
+          "val" : "Reactome:REACT_15386"
+        }, {
+          "val" : "Reactome:REACT_31466"
+        }, {
+          "val" : "Reactome:REACT_6311"
+        }, {
+          "val" : "Reactome:REACT_99966"
+        }, {
+          "val" : "Reactome:REACT_113269"
+        }, {
+          "val" : "Reactome:REACT_97847"
+        }, {
+          "val" : "Reactome:REACT_77365"
+        }, {
+          "val" : "Reactome:REACT_54449"
+        }, {
+          "val" : "Reactome:REACT_85328"
+        }, {
+          "val" : "Reactome:REACT_95087"
+        }, {
+          "val" : "Reactome:REACT_95052"
+        }, {
+          "val" : "Reactome:REACT_118307"
+        }, {
+          "val" : "Reactome:REACT_83089"
+        }, {
+          "val" : "Reactome:REACT_101431"
+        }, {
+          "val" : "Reactome:REACT_34741"
+        }, {
+          "val" : "Reactome:REACT_29213"
+        }, {
+          "val" : "Reactome:REACT_87010"
+        }, {
+          "val" : "Reactome:REACT_84656"
+        }, {
+          "val" : "Reactome:REACT_86211"
+        }, {
+          "val" : "Reactome:REACT_31625"
+        }, {
+          "val" : "Reactome:REACT_82128"
+        }, {
+          "val" : "Reactome:REACT_132"
+        }, {
+          "val" : "Reactome:REACT_109260"
+        }, {
+          "val" : "Reactome:REACT_101024"
+        }, {
+          "val" : "Reactome:REACT_94464"
+        }, {
+          "val" : "Reactome:REACT_1362"
+        }, {
+          "val" : "Reactome:REACT_108840"
+        }, {
+          "val" : "Reactome:REACT_107055"
+        }, {
+          "val" : "Reactome:REACT_98908"
+        }, {
+          "val" : "Reactome:REACT_92951"
+        }, {
+          "val" : "Reactome:REACT_100390"
+        }, {
+          "val" : "Reactome:REACT_82678"
+        }, {
+          "val" : "Reactome:REACT_77566"
+        }, {
+          "val" : "Reactome:REACT_91197"
+        }, {
+          "val" : "Reactome:REACT_102380"
+        }, {
+          "val" : "Reactome:REACT_80606"
+        }, {
+          "val" : "Reactome:REACT_80110"
+        }, {
+          "val" : "Reactome:REACT_31984"
+        }, {
+          "val" : "Reactome:REACT_28555"
+        }, {
+          "val" : "Reactome:REACT_496"
+        }, {
+          "val" : "Reactome:REACT_77857"
+        }, {
+          "val" : "Reactome:REACT_106144"
+        }, {
+          "val" : "Reactome:REACT_2066"
+        }, {
+          "val" : "Reactome:REACT_110583"
+        }, {
+          "val" : "Reactome:REACT_99713"
+        }, {
+          "val" : "Reactome:REACT_77362"
+        }, {
+          "val" : "Reactome:REACT_112101"
+        }, {
+          "val" : "Reactome:REACT_32077"
+        }, {
+          "val" : "Reactome:REACT_29289"
+        }, {
+          "val" : "Reactome:REACT_108394"
+        }, {
+          "val" : "Reactome:REACT_112270"
+        }, {
+          "val" : "Reactome:REACT_105976"
+        }, {
+          "val" : "Reactome:REACT_107736"
+        }, {
+          "val" : "Reactome:REACT_82303"
+        }, {
+          "val" : "Reactome:REACT_113121"
+        }, {
+          "val" : "Reactome:REACT_108985"
+        }, {
+          "val" : "Reactome:REACT_78625"
+        }, {
+          "val" : "Reactome:REACT_88326"
+        }, {
+          "val" : "Reactome:REACT_115475"
+        }, {
+          "val" : "Reactome:REACT_244"
+        }, {
+          "val" : "Reactome:REACT_89579"
+        }, {
+          "val" : "Reactome:REACT_93613"
+        }, {
+          "val" : "Reactome:REACT_104109"
+        }, {
+          "val" : "Reactome:REACT_78503"
+        }, {
+          "val" : "Reactome:REACT_113811"
+        }, {
+          "val" : "Reactome:REACT_83297"
+        }, {
+          "val" : "Reactome:REACT_112156"
+        }, {
+          "val" : "Reactome:REACT_32492"
+        }, {
+          "val" : "Reactome:REACT_79039"
+        }, {
+          "val" : "Reactome:REACT_112360"
+        }, {
+          "val" : "Reactome:REACT_84208"
+        }, {
+          "val" : "Reactome:REACT_85256"
+        }, {
+          "val" : "Reactome:REACT_110530"
+        }, {
+          "val" : "Reactome:REACT_91196"
+        }, {
+          "val" : "Reactome:REACT_29873"
+        }, {
+          "val" : "Reactome:REACT_80804"
+        }, {
+          "val" : "Reactome:REACT_9978"
+        }, {
+          "val" : "Reactome:REACT_85586"
+        }, {
+          "val" : "Reactome:REACT_105345"
+        }, {
+          "val" : "Reactome:REACT_34310"
+        }, {
+          "val" : "Reactome:REACT_31196"
+        }, {
+          "val" : "Reactome:REACT_30052"
+        }, {
+          "val" : "Reactome:REACT_79720"
+        }, {
+          "val" : "Reactome:REACT_88220"
+        }, {
+          "val" : "Reactome:REACT_82901"
+        }, {
+          "val" : "Reactome:REACT_97661"
+        }, {
+          "val" : "Reactome:REACT_110643"
+        }, {
+          "val" : "Reactome:REACT_9997"
+        }, {
+          "val" : "Reactome:REACT_82125"
+        }, {
+          "val" : "Reactome:REACT_96088"
+        }, {
+          "val" : "Reactome:REACT_107623"
+        }, {
+          "val" : "Reactome:REACT_102093"
+        }, {
+          "val" : "Reactome:REACT_80665"
+        }, {
+          "val" : "Reactome:REACT_97282"
+        }, {
+          "val" : "Reactome:REACT_114984"
+        }, {
+          "val" : "Reactome:REACT_28264"
+        }, {
+          "val" : "Reactome:REACT_112790"
+        }, {
+          "val" : "Reactome:REACT_77949"
+        }, {
+          "val" : "Reactome:REACT_1727"
+        }, {
+          "val" : "Reactome:REACT_83529"
+        }, {
+          "val" : "Reactome:REACT_6314"
+        }, {
+          "val" : "Reactome:REACT_99053"
+        }, {
+          "val" : "Reactome:REACT_81490"
+        }, {
+          "val" : "Reactome:REACT_103804"
+        }, {
+          "val" : "Reactome:REACT_28113"
+        }, {
+          "val" : "Reactome:REACT_96666"
+        }, {
+          "val" : "Reactome:REACT_94248"
+        }, {
+          "val" : "Reactome:REACT_908"
+        }, {
+          "val" : "Reactome:REACT_1120"
+        }, {
+          "val" : "Reactome:REACT_91085"
+        }, {
+          "val" : "Reactome:REACT_114395"
+        }, {
+          "val" : "Reactome:REACT_98373"
+        }, {
+          "val" : "Reactome:REACT_22378"
+        }, {
+          "val" : "Reactome:REACT_20503"
+        }, {
+          "val" : "Reactome:REACT_9983"
+        }, {
+          "val" : "Reactome:REACT_100260"
+        }, {
+          "val" : "Reactome:REACT_30084"
+        }, {
+          "val" : "Reactome:REACT_113569"
+        }, {
+          "val" : "Reactome:REACT_82751"
+        }, {
+          "val" : "Reactome:REACT_41715"
+        }, {
+          "val" : "Reactome:REACT_108132"
+        }, {
+          "val" : "Reactome:REACT_29395"
+        }, {
+          "val" : "Reactome:REACT_30921"
+        }, {
+          "val" : "Reactome:REACT_94428"
+        }, {
+          "val" : "Reactome:REACT_105561"
+        }, {
+          "val" : "Reactome:REACT_81864"
+        }, {
+          "val" : "Reactome:REACT_109799"
+        }, {
+          "val" : "Reactome:REACT_85745"
+        }, {
+          "val" : "Reactome:REACT_114434"
+        }, {
+          "val" : "Reactome:REACT_115440"
+        }, {
+          "val" : "Reactome:REACT_112480"
+        }, {
+          "val" : "Reactome:REACT_20578"
+        }, {
+          "val" : "Reactome:REACT_106411"
+        }, {
+          "val" : "Reactome:REACT_32598"
+        }, {
+          "val" : "Reactome:REACT_31449"
+        }, {
+          "val" : "Reactome:REACT_106681"
+        }, {
+          "val" : "Reactome:REACT_30165"
+        }, {
+          "val" : "Reactome:REACT_93219"
+        }, {
+          "val" : "Reactome:REACT_6870"
+        }, {
+          "val" : "Reactome:REACT_103060"
+        }, {
+          "val" : "Reactome:REACT_78014"
+        }, {
+          "val" : "Reactome:REACT_107685"
+        }, {
+          "val" : "Reactome:REACT_115006"
+        }, {
+          "val" : "Reactome:REACT_106897"
+        }, {
+          "val" : "Reactome:REACT_773"
+        }, {
+          "val" : "Reactome:REACT_98253"
+        }, {
+          "val" : "Reactome:REACT_77407"
+        }, {
+          "val" : "Reactome:REACT_113820"
+        }, {
+          "val" : "Reactome:REACT_98708"
+        }, {
+          "val" : "Reactome:REACT_115384"
+        }, {
+          "val" : "Reactome:REACT_102552"
+        }, {
+          "val" : "Reactome:REACT_99556"
+        }, {
+          "val" : "Reactome:REACT_109367"
+        }, {
+          "val" : "Reactome:REACT_6725"
+        }, {
+          "val" : "Reactome:REACT_9959"
+        }, {
+          "val" : "Reactome:REACT_215"
+        }, {
+          "val" : "Reactome:REACT_29334"
+        }, {
+          "val" : "Reactome:REACT_86033"
+        }, {
+          "val" : "Reactome:REACT_118367"
+        }, {
+          "val" : "Reactome:REACT_91240"
+        }, {
+          "val" : "Reactome:REACT_87497"
+        }, {
+          "val" : "Reactome:REACT_29201"
+        }, {
+          "val" : "Reactome:REACT_92735"
+        }, {
+          "val" : "Reactome:REACT_98558"
+        }, {
+          "val" : "Reactome:REACT_110175"
+        }, {
+          "val" : "Reactome:REACT_96097"
+        }, {
+          "val" : "Reactome:REACT_106500"
+        }, {
+          "val" : "Reactome:REACT_6873"
+        }, {
+          "val" : "Reactome:REACT_79372"
+        }, {
+          "val" : "Reactome:REACT_90675"
+        }, {
+          "val" : "Reactome:REACT_93018"
+        }, {
+          "val" : "Reactome:REACT_26"
+        }, {
+          "val" : "Reactome:REACT_81148"
+        }, {
+          "val" : "Reactome:REACT_85044"
+        }, {
+          "val" : "Reactome:REACT_118137"
+        }, {
+          "val" : "Reactome:REACT_97748"
+        }, {
+          "val" : "Reactome:REACT_99311"
+        }, {
+          "val" : "Reactome:REACT_108971"
+        }, {
+          "val" : "Reactome:REACT_28091"
+        }, {
+          "val" : "Reactome:REACT_116149"
+        }, {
+          "val" : "Reactome:REACT_86365"
+        }, {
+          "val" : "Reactome:REACT_87329"
+        }, {
+          "val" : "Reactome:REACT_95088"
+        }, {
+          "val" : "Reactome:REACT_87212"
+        }, {
+          "val" : "Reactome:REACT_86967"
+        }, {
+          "val" : "Reactome:REACT_87437"
+        }, {
+          "val" : "Reactome:REACT_30230"
+        }, {
+          "val" : "Reactome:REACT_90364"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "phosphokinase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term encompasses all activities that transfer a single phosphate group; although ATP is by far the most common phosphate donor, reactions using other phosphate donors are included in this term."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kinase activity"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#inSubset",
+      "type" : "PROPERTY",
+      "lbl" : "in_subset"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016302",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016791"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0034655",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways resulting in the breakdown of nucleobases, nucleosides, nucleotides and nucleic acids.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "nucleobase, nucleoside, nucleotide and nucleic acid catabolism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "nucleobase, nucleoside, nucleotide and nucleic acid breakdown",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "nucleobase, nucleoside, nucleotide and nucleic acid catabolic process",
+          "xrefs" : [ "GOC:dph", "GOC:tb" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "nucleobase, nucleoside, nucleotide and nucleic acid degradation",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nucleobase-containing compound catabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009579",
+      "meta" : {
+        "definition" : {
+          "val" : "A membranous cellular structure that bears the photosynthetic pigments in plants, algae, and cyanobacteria. In cyanobacteria thylakoids are of various shapes and are attached to, or continuous with, the plasma membrane. In eukaryotes they are flattened, membrane-bounded disk-like structures located in the chloroplasts; in the chloroplasts of higher plants the thylakoids form dense stacks called grana. Isolated thylakoid preparations can carry out photosynthetic electron transport and the associated phosphorylation.",
+          "xrefs" : [ "GOC:ds", "GOC:mtg_sensu", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Thylakoid"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "photosynthetic membrane",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "A thylakoid is not considered an organelle, but some thylakoids are part of organelles."
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "thylakoid"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0015457",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006810"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "ChEMBL protein targets summary"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0051276",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that is carried out at the cellular level that results in the assembly, arrangement of constituent parts, or disassembly of chromosomes, structures composed of a very long molecule of DNA and associated proteins that carries hereditary information. This term covers covalent modifications at the molecular level as well as spatial relationships among the major components of a chromosome.",
+          "xrefs" : [ "GOC:ai", "GOC:dph", "GOC:jl", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "chromosome organisation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "chromosome organization and biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "nuclear genome maintenance",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "maintenance of genome integrity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0007001"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0051277"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "chromosome organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0051277",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0051276"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006629",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving lipids, compounds soluble in an organic solvent but not, or sparingly, in an aqueous solvent. Includes fatty acids; neutral fats, other fatty-acid esters, and soaps; long-chain (fatty) alcohols and waxes; sphingoids and other long-chain bases; glycolipids, phospholipids and sphingolipids; and carotenes, polyprenols, sterols, terpenes and other isoprenoids.",
+          "xrefs" : [ "GOC:ma" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_104930"
+        }, {
+          "val" : "Reactome:REACT_32539"
+        }, {
+          "val" : "Reactome:REACT_77191"
+        }, {
+          "val" : "Reactome:REACT_97906"
+        }, {
+          "val" : "Reactome:REACT_79244"
+        }, {
+          "val" : "Reactome:REACT_99706"
+        }, {
+          "val" : "Reactome:REACT_77176"
+        }, {
+          "val" : "Reactome:REACT_98129"
+        }, {
+          "val" : "Reactome:REACT_33836"
+        }, {
+          "val" : "Reactome:REACT_114669"
+        }, {
+          "val" : "Reactome:REACT_108775"
+        }, {
+          "val" : "Reactome:REACT_82723"
+        }, {
+          "val" : "Reactome:REACT_115652"
+        }, {
+          "val" : "Reactome:REACT_81778"
+        }, {
+          "val" : "Reactome:REACT_31395"
+        }, {
+          "val" : "Reactome:REACT_90757"
+        }, {
+          "val" : "Reactome:REACT_82512"
+        }, {
+          "val" : "Wikipedia:Lipid_metabolism"
+        }, {
+          "val" : "Reactome:REACT_87884"
+        }, {
+          "val" : "Reactome:REACT_94607"
+        }, {
+          "val" : "Reactome:REACT_107479"
+        }, {
+          "val" : "Reactome:REACT_602"
+        }, {
+          "val" : "Reactome:REACT_28745"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "lipid metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "lipid metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0050877",
+      "meta" : {
+        "definition" : {
+          "val" : "A organ system process carried out by any of the organs or tissues of neurological system.",
+          "xrefs" : [ "GOC:ai", "GOC:mtg_cardio" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "neurological system process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "neurophysiological process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "pan-neural process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Discussion of class label and synonyms: https://github.com/geneontology/go-ontology/issues/13824"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nervous system process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0051604",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process leading to the attainment of the full functional capacity of a protein.",
+          "xrefs" : [ "GOC:ai" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein maturation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0050876",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0000003"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007049",
+      "meta" : {
+        "definition" : {
+          "val" : "The progression of biochemical and morphological phases and events that occur in a cell during successive cell replication or nuclear replication events. Canonically, the cell cycle comprises the replication and segregation of genetic material followed by the division of the cell, but in endocycles or syncytial cells nuclear replication or nuclear division may not be followed by cell division.",
+          "xrefs" : [ "GOC:go_curators", "GOC:mtg_cell_cycle" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_manually_annotate", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cell_cycle"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell-division cycle",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell cycle"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005783",
+      "meta" : {
+        "definition" : {
+          "val" : "The irregular network of unit membranes, visible only by electron microscopy, that occurs in the cytoplasm of many eukaryotic cells. The membranes form a complex meshwork of tubular channels, which are often expanded into slitlike cavities called cisternae. The ER takes two forms, rough (or granular), with ribosomes adhering to the outer surface, and smooth (with no ribosomes attached).",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1036339110"
+        }, {
+          "val" : "Wikipedia:Endoplasmic_reticulum"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "ER",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "endoplasmic reticulum"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008135",
+      "meta" : {
+        "definition" : {
+          "val" : "Functions during translation by interacting selectively and non-covalently with RNA during polypeptide synthesis at the ribosome.",
+          "xrefs" : [ "GOC:ai", "GOC:vw" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasBroadSynonym",
+          "val" : "translation factor activity, nucleic acid binding",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "translation factor activity, RNA binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007046",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0042254"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008134",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with a transcription factor, any protein required to initiate or regulate transcription.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "TF binding",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transcription factor binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007165",
+      "meta" : {
+        "definition" : {
+          "val" : "The cellular process in which a signal is conveyed to trigger a change in the activity or state of a cell. Signal transduction begins with reception of a signal (e.g. a ligand binding to a receptor or receptor activation by a stimulus such as light), or for signal transduction in the absence of ligand, signal-withdrawal or the activity of a constitutively active receptor. Signal transduction ends with regulation of a downstream cellular process, e.g. regulation of transcription or regulation of a metabolic process. Signal transduction covers signaling from receptors located on the surface of the cell and signaling via molecules located within the cell. For signaling between cells, signal transduction is restricted to events at and within the receiving cell.",
+          "xrefs" : [ "GOC:go_curators", "GOC:mtg_signaling_feb11" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_100624"
+        }, {
+          "val" : "Reactome:REACT_89740"
+        }, {
+          "val" : "Reactome:REACT_12478"
+        }, {
+          "val" : "Reactome:REACT_102354"
+        }, {
+          "val" : "Reactome:REACT_113964"
+        }, {
+          "val" : "Reactome:REACT_115037"
+        }, {
+          "val" : "Reactome:REACT_114910"
+        }, {
+          "val" : "Reactome:REACT_31232"
+        }, {
+          "val" : "Reactome:REACT_114690"
+        }, {
+          "val" : "Reactome:REACT_115147"
+        }, {
+          "val" : "Wikipedia:Signal_transduction"
+        }, {
+          "val" : "Reactome:REACT_114657"
+        }, {
+          "val" : "Reactome:REACT_112549"
+        }, {
+          "val" : "Reactome:REACT_112130"
+        }, {
+          "val" : "Reactome:REACT_113601"
+        }, {
+          "val" : "Reactome:REACT_114820"
+        }, {
+          "val" : "Reactome:REACT_93680"
+        }, {
+          "val" : "Reactome:REACT_98872"
+        }, {
+          "val" : "Reactome:REACT_113151"
+        }, {
+          "val" : "Reactome:REACT_78535"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "signalling pathway",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "signaling cascade",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "signalling cascade",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "signaling pathway",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that signal transduction is defined broadly to include a ligand interacting with a receptor, downstream signaling steps and a response being triggered. A change in form of the signal in every step is not necessary. Note that in many cases the end of this process is regulation of the initiation of transcription. Note that specific transcription factors may be annotated to this term, but core/general transcription machinery such as RNA polymerase should not."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0023033"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "signal transduction"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0055085",
+      "meta" : {
+        "definition" : {
+          "val" : "The process in which a solute is transported across a lipid bilayer, from one side of a membrane to the other.",
+          "xrefs" : [ "GOC:dph", "GOC:jid" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_32055"
+        }, {
+          "val" : "Reactome:REACT_99829"
+        }, {
+          "val" : "Reactome:REACT_15518"
+        }, {
+          "val" : "Reactome:REACT_114763"
+        }, {
+          "val" : "Reactome:REACT_87124"
+        }, {
+          "val" : "Reactome:REACT_86409"
+        }, {
+          "val" : "Reactome:REACT_94160"
+        }, {
+          "val" : "Reactome:REACT_30969"
+        }, {
+          "val" : "Reactome:REACT_100480"
+        }, {
+          "val" : "Reactome:REACT_19118"
+        }, {
+          "val" : "Reactome:REACT_88894"
+        }, {
+          "val" : "Reactome:REACT_93747"
+        }, {
+          "val" : "Reactome:REACT_102974"
+        }, {
+          "val" : "Reactome:REACT_80977"
+        }, {
+          "val" : "Reactome:REACT_80848"
+        }, {
+          "val" : "Reactome:REACT_96633"
+        }, {
+          "val" : "Reactome:REACT_108243"
+        }, {
+          "val" : "Reactome:REACT_91803"
+        }, {
+          "val" : "Reactome:REACT_99579"
+        }, {
+          "val" : "Reactome:REACT_29093"
+        }, {
+          "val" : "Reactome:REACT_89376"
+        }, {
+          "val" : "Reactome:REACT_32223"
+        }, {
+          "val" : "Reactome:REACT_102897"
+        }, {
+          "val" : "Reactome:REACT_92624"
+        }, {
+          "val" : "Reactome:REACT_33571"
+        }, {
+          "val" : "Reactome:REACT_94944"
+        }, {
+          "val" : "Reactome:REACT_32423"
+        }, {
+          "val" : "Reactome:REACT_101975"
+        }, {
+          "val" : "Reactome:REACT_32713"
+        }, {
+          "val" : "Reactome:REACT_114890"
+        }, {
+          "val" : "Reactome:REACT_97867"
+        }, {
+          "val" : "Reactome:REACT_101577"
+        }, {
+          "val" : "Reactome:REACT_80510"
+        }, {
+          "val" : "Reactome:REACT_102348"
+        }, {
+          "val" : "Reactome:REACT_86135"
+        }, {
+          "val" : "Reactome:REACT_83770"
+        }, {
+          "val" : "Reactome:REACT_80022"
+        }, {
+          "val" : "Reactome:REACT_79921"
+        }, {
+          "val" : "Reactome:REACT_109832"
+        }, {
+          "val" : "Reactome:REACT_91272"
+        }, {
+          "val" : "Reactome:REACT_81024"
+        }, {
+          "val" : "Reactome:REACT_94972"
+        }, {
+          "val" : "Reactome:REACT_114546"
+        }, {
+          "val" : "Reactome:REACT_81153"
+        }, {
+          "val" : "Reactome:REACT_82725"
+        }, {
+          "val" : "Reactome:REACT_104555"
+        }, {
+          "val" : "Reactome:REACT_88521"
+        }, {
+          "val" : "Reactome:REACT_29635"
+        }, {
+          "val" : "Reactome:REACT_94393"
+        }, {
+          "val" : "Reactome:REACT_61245"
+        }, {
+          "val" : "Reactome:REACT_115378"
+        }, {
+          "val" : "Reactome:REACT_29184"
+        }, {
+          "val" : "Reactome:REACT_86576"
+        }, {
+          "val" : "Reactome:REACT_88059"
+        }, {
+          "val" : "Reactome:REACT_79086"
+        }, {
+          "val" : "Reactome:REACT_101877"
+        }, {
+          "val" : "Reactome:REACT_15480"
+        }, {
+          "val" : "Reactome:REACT_110770"
+        }, {
+          "val" : "Reactome:REACT_98509"
+        }, {
+          "val" : "Reactome:REACT_96636"
+        }, {
+          "val" : "Reactome:REACT_97365"
+        }, {
+          "val" : "Reactome:REACT_92006"
+        }, {
+          "val" : "Reactome:REACT_98716"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "membrane transport",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Transmembrane transport requires transport of a solute across a lipid bilayer. Note that transport through the nuclear pore complex is not transmembrane because the nuclear membrane is a double membrane and is not traversed. For transport through the nuclear pore, consider instead the term 'nucleocytoplasmic transport ; GO:0006913' and its children. Note also that this term is not intended for use in annotating lateral movement within membranes."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transmembrane transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0034641",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving various organic and inorganic nitrogenous compounds, as carried out by individual cells.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_13"
+        }, {
+          "val" : "Reactome:REACT_99241"
+        }, {
+          "val" : "Reactome:REACT_32429"
+        }, {
+          "val" : "Reactome:REACT_93580"
+        }, {
+          "val" : "Reactome:REACT_107293"
+        }, {
+          "val" : "Reactome:REACT_86268"
+        }, {
+          "val" : "Reactome:REACT_108179"
+        }, {
+          "val" : "Reactome:REACT_33347"
+        }, {
+          "val" : "Reactome:REACT_29108"
+        }, {
+          "val" : "Reactome:REACT_102000"
+        }, {
+          "val" : "Reactome:REACT_55564"
+        }, {
+          "val" : "Reactome:REACT_34326"
+        }, {
+          "val" : "Reactome:REACT_95666"
+        }, {
+          "val" : "Reactome:REACT_82379"
+        }, {
+          "val" : "Reactome:REACT_90299"
+        }, {
+          "val" : "Reactome:REACT_109042"
+        }, {
+          "val" : "Reactome:REACT_91959"
+        }, {
+          "val" : "Reactome:REACT_28699"
+        }, {
+          "val" : "Reactome:REACT_77741"
+        }, {
+          "val" : "Reactome:REACT_103710"
+        }, {
+          "val" : "Reactome:REACT_98086"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular nitrogen compound metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cellular nitrogen compound metabolic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0010576",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0030234"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0085031",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0044403"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0140014",
+      "meta" : {
+        "definition" : {
+          "val" : "A mitotic cell cycle process comprising the steps by which the nucleus of a eukaryotic cell divides; the process involves condensation of chromosomal DNA into a highly compacted form. Canonically, mitosis produces two daughter nuclei whose chromosome complement is identical to that of the mother cell.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "pg"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2017-03-23T14:44:23Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mitotic nuclear division"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016798",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the hydrolysis of any glycosyl bond.",
+          "xrefs" : [ "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "EC:3.2"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "glycosylase",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "N-glycosylase",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "glycosidase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "hydrolase activity, acting on glycosyl bonds"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0015463",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0008565"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+      "type" : "PROPERTY",
+      "lbl" : "has_broad_synonym"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0003924",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the reaction: GTP + H2O = GDP + phosphate.",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_80275"
+        }, {
+          "val" : "Reactome:REACT_12456"
+        }, {
+          "val" : "Reactome:REACT_348"
+        }, {
+          "val" : "Reactome:REACT_87653"
+        }, {
+          "val" : "Reactome:REACT_105854"
+        }, {
+          "val" : "Reactome:REACT_113727"
+        }, {
+          "val" : "Reactome:REACT_32914"
+        }, {
+          "val" : "Reactome:REACT_96223"
+        }, {
+          "val" : "Reactome:REACT_95238"
+        }, {
+          "val" : "Reactome:REACT_87506"
+        }, {
+          "val" : "Reactome:REACT_83440"
+        }, {
+          "val" : "Reactome:REACT_112104"
+        }, {
+          "val" : "Reactome:REACT_82704"
+        }, {
+          "val" : "Reactome:REACT_31226"
+        }, {
+          "val" : "Reactome:REACT_105708"
+        }, {
+          "val" : "Reactome:REACT_92197"
+        }, {
+          "val" : "Reactome:REACT_110131"
+        }, {
+          "val" : "Reactome:REACT_106301"
+        }, {
+          "val" : "Reactome:REACT_103518"
+        }, {
+          "val" : "Reactome:REACT_15316"
+        }, {
+          "val" : "Reactome:REACT_93249"
+        }, {
+          "val" : "Reactome:REACT_85972"
+        }, {
+          "val" : "Reactome:REACT_88045"
+        }, {
+          "val" : "Reactome:REACT_12397"
+        }, {
+          "val" : "Reactome:REACT_89292"
+        }, {
+          "val" : "Reactome:REACT_111994"
+        }, {
+          "val" : "Reactome:REACT_34113"
+        }, {
+          "val" : "Reactome:REACT_30562"
+        }, {
+          "val" : "Reactome:REACT_93742"
+        }, {
+          "val" : "Reactome:REACT_19186"
+        }, {
+          "val" : "Reactome:REACT_113952"
+        }, {
+          "val" : "Reactome:REACT_19123"
+        }, {
+          "val" : "Reactome:REACT_112587"
+        }, {
+          "val" : "Reactome:REACT_96612"
+        }, {
+          "val" : "Reactome:REACT_89668"
+        }, {
+          "val" : "Reactome:REACT_101121"
+        }, {
+          "val" : "Reactome:REACT_110859"
+        }, {
+          "val" : "Reactome:REACT_110879"
+        }, {
+          "val" : "Reactome:REACT_92198"
+        }, {
+          "val" : "Reactome:REACT_85008"
+        }, {
+          "val" : "Reactome:REACT_82457"
+        }, {
+          "val" : "Reactome:REACT_32006"
+        }, {
+          "val" : "Reactome:REACT_28251"
+        }, {
+          "val" : "Reactome:REACT_110557"
+        }, {
+          "val" : "Reactome:REACT_90050"
+        }, {
+          "val" : "Reactome:REACT_110931"
+        }, {
+          "val" : "Reactome:REACT_114148"
+        }, {
+          "val" : "Reactome:REACT_79558"
+        }, {
+          "val" : "Reactome:REACT_84204"
+        }, {
+          "val" : "Reactome:REACT_98556"
+        }, {
+          "val" : "Reactome:REACT_105697"
+        }, {
+          "val" : "Reactome:REACT_100432"
+        }, {
+          "val" : "Reactome:REACT_75799"
+        }, {
+          "val" : "Reactome:REACT_31599"
+        }, {
+          "val" : "Reactome:REACT_101678"
+        }, {
+          "val" : "Reactome:REACT_31709"
+        }, {
+          "val" : "Reactome:REACT_34480"
+        }, {
+          "val" : "Reactome:REACT_30942"
+        }, {
+          "val" : "Reactome:REACT_77032"
+        }, {
+          "val" : "Reactome:REACT_96019"
+        }, {
+          "val" : "Reactome:REACT_102532"
+        }, {
+          "val" : "Reactome:REACT_84735"
+        }, {
+          "val" : "Reactome:REACT_22359"
+        }, {
+          "val" : "Reactome:REACT_19194"
+        }, {
+          "val" : "Reactome:REACT_78231"
+        }, {
+          "val" : "Reactome:REACT_15495"
+        }, {
+          "val" : "Reactome:REACT_88357"
+        }, {
+          "val" : "Reactome:REACT_32028"
+        }, {
+          "val" : "Reactome:REACT_94095"
+        }, {
+          "val" : "Reactome:REACT_114379"
+        }, {
+          "val" : "Reactome:REACT_115229"
+        }, {
+          "val" : "Reactome:REACT_107820"
+        }, {
+          "val" : "Reactome:REACT_109360"
+        }, {
+          "val" : "Reactome:REACT_107176"
+        }, {
+          "val" : "Reactome:REACT_91588"
+        }, {
+          "val" : "Reactome:REACT_98431"
+        }, {
+          "val" : "Reactome:REACT_91199"
+        }, {
+          "val" : "Reactome:REACT_97405"
+        }, {
+          "val" : "Reactome:REACT_86227"
+        }, {
+          "val" : "Reactome:REACT_84696"
+        }, {
+          "val" : "Reactome:REACT_84712"
+        }, {
+          "val" : "Reactome:REACT_82263"
+        }, {
+          "val" : "Reactome:REACT_104739"
+        }, {
+          "val" : "Reactome:REACT_112671"
+        }, {
+          "val" : "Reactome:REACT_101563"
+        }, {
+          "val" : "Reactome:REACT_30707"
+        }, {
+          "val" : "Reactome:REACT_712"
+        }, {
+          "val" : "Reactome:REACT_89763"
+        }, {
+          "val" : "Reactome:REACT_97284"
+        }, {
+          "val" : "Reactome:REACT_87558"
+        }, {
+          "val" : "Reactome:REACT_6171"
+        }, {
+          "val" : "Reactome:REACT_94760"
+        }, {
+          "val" : "Reactome:REACT_94305"
+        }, {
+          "val" : "Reactome:REACT_113832"
+        }, {
+          "val" : "Reactome:REACT_104477"
+        }, {
+          "val" : "Reactome:REACT_114153"
+        }, {
+          "val" : "Reactome:REACT_93305"
+        }, {
+          "val" : "Reactome:REACT_98837"
+        }, {
+          "val" : "Reactome:REACT_102307"
+        }, {
+          "val" : "Reactome:REACT_78945"
+        }, {
+          "val" : "Reactome:REACT_30463"
+        }, {
+          "val" : "Reactome:REACT_108837"
+        }, {
+          "val" : "Reactome:REACT_90703"
+        }, {
+          "val" : "Reactome:REACT_30687"
+        }, {
+          "val" : "Reactome:REACT_97794"
+        }, {
+          "val" : "Reactome:REACT_87409"
+        }, {
+          "val" : "Reactome:REACT_34735"
+        }, {
+          "val" : "Reactome:REACT_36834"
+        }, {
+          "val" : "Reactome:REACT_102371"
+        }, {
+          "val" : "Reactome:REACT_81580"
+        }, {
+          "val" : "Reactome:REACT_94019"
+        }, {
+          "val" : "Reactome:REACT_81664"
+        }, {
+          "val" : "Reactome:REACT_108653"
+        }, {
+          "val" : "Reactome:REACT_81304"
+        }, {
+          "val" : "Reactome:REACT_12612"
+        }, {
+          "val" : "Reactome:REACT_33948"
+        }, {
+          "val" : "Reactome:REACT_98859"
+        }, {
+          "val" : "Reactome:REACT_84553"
+        }, {
+          "val" : "Reactome:REACT_114620"
+        }, {
+          "val" : "Reactome:REACT_78653"
+        }, {
+          "val" : "Reactome:REACT_86760"
+        }, {
+          "val" : "Reactome:REACT_92450"
+        }, {
+          "val" : "Reactome:REACT_31474"
+        }, {
+          "val" : "Reactome:REACT_106121"
+        }, {
+          "val" : "Reactome:REACT_77303"
+        }, {
+          "val" : "Reactome:REACT_93641"
+        }, {
+          "val" : "Reactome:REACT_108363"
+        }, {
+          "val" : "Reactome:REACT_12396"
+        }, {
+          "val" : "Reactome:REACT_102040"
+        }, {
+          "val" : "Reactome:REACT_92176"
+        }, {
+          "val" : "Reactome:REACT_108825"
+        }, {
+          "val" : "Reactome:REACT_113209"
+        }, {
+          "val" : "Reactome:REACT_114188"
+        }, {
+          "val" : "Reactome:REACT_83403"
+        }, {
+          "val" : "Reactome:REACT_85769"
+        }, {
+          "val" : "Reactome:REACT_107306"
+        }, {
+          "val" : "Reactome:REACT_96132"
+        }, {
+          "val" : "Reactome:REACT_95563"
+        }, {
+          "val" : "Reactome:REACT_80612"
+        }, {
+          "val" : "RHEA:19672"
+        }, {
+          "val" : "Reactome:REACT_114384"
+        }, {
+          "val" : "Reactome:REACT_28065"
+        }, {
+          "val" : "Reactome:REACT_112389"
+        }, {
+          "val" : "Reactome:REACT_96881"
+        }, {
+          "val" : "Reactome:REACT_97595"
+        }, {
+          "val" : "Reactome:REACT_28269"
+        }, {
+          "val" : "Reactome:REACT_114824"
+        }, {
+          "val" : "Reactome:REACT_552"
+        }, {
+          "val" : "Reactome:REACT_114331"
+        }, {
+          "val" : "Reactome:REACT_31530"
+        }, {
+          "val" : "Reactome:REACT_19255"
+        }, {
+          "val" : "Reactome:REACT_100708"
+        }, {
+          "val" : "Reactome:REACT_106217"
+        }, {
+          "val" : "Reactome:REACT_34592"
+        }, {
+          "val" : "Reactome:REACT_37542"
+        }, {
+          "val" : "Reactome:REACT_19219"
+        }, {
+          "val" : "Reactome:REACT_114210"
+        }, {
+          "val" : "Reactome:REACT_110443"
+        }, {
+          "val" : "Reactome:REACT_107730"
+        }, {
+          "val" : "Reactome:REACT_112651"
+        }, {
+          "val" : "Reactome:REACT_113954"
+        }, {
+          "val" : "Reactome:REACT_19178"
+        }, {
+          "val" : "Reactome:REACT_79620"
+        }, {
+          "val" : "Reactome:REACT_99479"
+        }, {
+          "val" : "Reactome:REACT_83308"
+        }, {
+          "val" : "Reactome:REACT_102510"
+        }, {
+          "val" : "Reactome:REACT_86630"
+        }, {
+          "val" : "Reactome:REACT_99533"
+        }, {
+          "val" : "Reactome:REACT_90064"
+        }, {
+          "val" : "Reactome:REACT_99616"
+        }, {
+          "val" : "Reactome:REACT_81448"
+        }, {
+          "val" : "Reactome:REACT_15449"
+        }, {
+          "val" : "Reactome:REACT_19317"
+        }, {
+          "val" : "Reactome:REACT_82203"
+        }, {
+          "val" : "Reactome:REACT_30456"
+        }, {
+          "val" : "Reactome:REACT_90517"
+        }, {
+          "val" : "Reactome:REACT_85418"
+        }, {
+          "val" : "Reactome:REACT_89416"
+        }, {
+          "val" : "Reactome:REACT_113058"
+        }, {
+          "val" : "Reactome:REACT_115324"
+        }, {
+          "val" : "Reactome:REACT_82603"
+        }, {
+          "val" : "Reactome:REACT_114532"
+        }, {
+          "val" : "Reactome:REACT_83730"
+        }, {
+          "val" : "Reactome:REACT_105323"
+        }, {
+          "val" : "Reactome:REACT_31850"
+        }, {
+          "val" : "Reactome:REACT_81879"
+        }, {
+          "val" : "Reactome:REACT_109897"
+        }, {
+          "val" : "Reactome:REACT_104081"
+        }, {
+          "val" : "Reactome:REACT_93772"
+        }, {
+          "val" : "Reactome:REACT_15335"
+        }, {
+          "val" : "Reactome:REACT_102208"
+        }, {
+          "val" : "Reactome:REACT_78069"
+        }, {
+          "val" : "Reactome:REACT_86400"
+        }, {
+          "val" : "Reactome:REACT_106528"
+        }, {
+          "val" : "Reactome:REACT_29162"
+        }, {
+          "val" : "Reactome:REACT_101520"
+        }, {
+          "val" : "Reactome:REACT_86972"
+        }, {
+          "val" : "Reactome:REACT_31727"
+        }, {
+          "val" : "Reactome:REACT_112254"
+        }, {
+          "val" : "Reactome:REACT_87661"
+        }, {
+          "val" : "Reactome:REACT_86358"
+        }, {
+          "val" : "Reactome:REACT_89231"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "RHEB small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "signal-recognition-particle GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "dynamin GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "Ran small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein-synthesizing GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "Sar small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "tubulin GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "heterotrimeric G-protein GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "hydrolase activity, acting on acid anhydrides, acting on GTP, involved in cellular and subcellular movement",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "heterotrimeric G-protein GTPase, gamma-subunit",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "heterotrimeric G-protein GTPase, alpha-subunit",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "Rab small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "ARF small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein-synthesizing GTPase activity, elongation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein-synthesizing GTPase activity, termination",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein-synthesizing GTPase activity, initiation",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "Rho small monomeric GTPase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "heterotrimeric G-protein GTPase, beta-subunit",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "Ras small monomeric GTPase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "GTPase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0071554",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that results in the biosynthesis of constituent macromolecules, assembly, arrangement of constituent parts, or disassembly of a cell wall.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell wall organization or biogenesis at cellular level",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular cell wall organisation or biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular cell wall organization or biogenesis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cell wall organisation or biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "midori"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2010-01-13T03:19:38Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0070882"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell wall organization or biogenesis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Generic GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_virus",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Viral GO slim"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006519",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006520"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016791",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the hydrolysis of phosphoric monoesters, releasing inorganic phosphate.",
+          "xrefs" : [ "EC:3.1.3", "EC:3.1.3.41", "GOC:curators", "GOC:pg" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida" ],
+        "xrefs" : [ {
+          "val" : "RHEA:21667"
+        }, {
+          "val" : "EC:3.1.3"
+        }, {
+          "val" : "EC:3.1.3.41"
+        }, {
+          "val" : "MetaCyc:4-NITROPHENYLPHOSPHATASE-RXN"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "p-nitrophenylphosphate phosphohydrolase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "PNPPase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "ecto-p-nitrophenyl phosphatase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "4-nitrophenylphosphate phosphohydrolase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "phosphatase",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "4-nitrophenylphosphatase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "nitrophenyl phosphatase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "para-nitrophenyl phosphatase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "p-nitrophenylphosphatase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "K-pNPPase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "phosphoric monoester hydrolase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "NPPase activity",
+          "xrefs" : [ "EC:3.1.3.41" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016302"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0003869"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "phosphatase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0015460",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006810"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006605",
+      "meta" : {
+        "definition" : {
+          "val" : "The process of targeting specific proteins to particular regions of the cell, typically membrane-bounded subcellular organelles. Usually requires an organelle specific protein sequence motif.",
+          "xrefs" : [ "GOC:ma" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Protein_targeting"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "protein sorting along secretory pathway",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "nascent polypeptide association",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that protein targeting encompasses the transport of the protein to the specified location, and may also include additional steps such as protein processing."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "protein targeting"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0022891",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0022857"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005635",
+      "meta" : {
+        "definition" : {
+          "val" : "The double lipid bilayer enclosing the nucleus and separating its contents from the rest of the cytoplasm; includes the intermembrane space, a gap of width 20-40 nm (also called the perinuclear space).",
+          "xrefs" : [ "ISBN:0198547684" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Nuclear_envelope"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0005636"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nuclear envelope"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0022892",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0022857"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005636",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0005635"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+      "type" : "PROPERTY",
+      "lbl" : "has_exact_synonym"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005634",
+      "meta" : {
+        "definition" : {
+          "val" : "A membrane-bounded organelle of eukaryotic cells in which chromosomes are housed and replicated. In most cells, the nucleus contains all of the cell's chromosomes except the organellar chromosomes, and is the site of RNA synthesis and processing. In some species, or in specialized cell types, RNA metabolism or DNA replication may be absent.",
+          "xrefs" : [ "GOC:go_curators" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1702920020"
+        }, {
+          "val" : "Wikipedia:Cell_nucleus"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasNarrowSynonym",
+          "val" : "horsetail nucleus",
+          "xrefs" : [ "GOC:al", "GOC:mah", "GOC:vw", "PMID:15030757" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cell nucleus",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nucleus"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+      "type" : "PROPERTY",
+      "lbl" : "database_cross_reference"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044765",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006810"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005198",
+      "meta" : {
+        "definition" : {
+          "val" : "The action of a molecule that contributes to the structural integrity of a complex or its assembly within or outside a cell.",
+          "xrefs" : [ "GOC:mah", "GOC:vw" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "structural molecule activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000063",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006913"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007010",
+      "meta" : {
+        "definition" : {
+          "val" : "A process that is carried out at the cellular level which results in the assembly, arrangement of constituent parts, or disassembly of cytoskeletal structures.",
+          "xrefs" : [ "GOC:dph", "GOC:jl", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cytoskeleton organisation",
+          "xrefs" : [ "GOC:curators" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cytoskeletal regulator activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cytoskeleton organization and biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "cytoskeletal organization and biogenesis",
+          "xrefs" : [ "GOC:mah" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoskeleton organization"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0009795",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0009790"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044403",
+      "meta" : {
+        "definition" : {
+          "val" : "A process carried out by symbiont gene products that enables a symbiotic interaction with a host organism. The various forms of symbiosis include parasitism, in which the association is disadvantageous or destructive to one of the organisms; mutualism, in which the association is advantageous, or often necessary to one or both and not harmful to either; and commensalism, in which one member of the association benefits while the other is not affected. However, mutualism, parasitism, and commensalism are often not discrete categories of interactions and should rather be perceived as a continuum of interaction ranging from parasitism to mutualism. In fact, the direction of a symbiotic interaction can change during the lifetime of the symbionts due to developmental changes as well as changes in the biotic/abiotic environment in which the interaction occurs. Microscopic symbionts are often referred to as endosymbionts.",
+          "xrefs" : [ "GOC:cc", "https://study.com/academy/lesson/symbiont-definition-lesson-quiz.html" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "symbiosis, encompassing mutualism through parasitism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "commensalism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "symbiotic interaction between host and organism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "symbiosis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "host-pathogen interaction",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "symbiotic interaction between organisms",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "parasitism",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "symbiotic interaction between species",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "symbiotic interaction",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0072519"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0085031"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0044404"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0043298"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Changed term, definition see https://github.com/geneontology/go-ontology/issues/14807"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "symbiont process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016765",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the transfer of an alkyl or aryl (but not methyl) group from one compound (donor) to another (acceptor).",
+          "xrefs" : [ "GOC:jl", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "xrefs" : [ {
+          "val" : "EC:2.5"
+        }, {
+          "val" : "EC:2.5.1"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "transferase activity, transferring alkyl or aryl groups, other than methyl groups",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0016766"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transferase activity, transferring alkyl or aryl (other than methyl) groups"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016887",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the reaction: ATP + H2O = ADP + phosphate + 2 H+. May or may not be coupled to another reaction.",
+          "xrefs" : [ "EC:3.6.1.3", "GOC:jl" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_100141"
+        }, {
+          "val" : "RHEA:13068"
+        }, {
+          "val" : "Reactome:REACT_89934"
+        }, {
+          "val" : "Reactome:REACT_84196"
+        }, {
+          "val" : "Reactome:REACT_18320"
+        }, {
+          "val" : "EC:3.6.1.3"
+        }, {
+          "val" : "Reactome:REACT_79964"
+        }, {
+          "val" : "MetaCyc:ADENOSINETRIPHOSPHATASE-RXN"
+        }, {
+          "val" : "Reactome:REACT_87020"
+        }, {
+          "val" : "Reactome:REACT_27184"
+        }, {
+          "val" : "Reactome:REACT_33329"
+        }, {
+          "val" : "Reactome:REACT_110992"
+        }, {
+          "val" : "Reactome:REACT_108873"
+        }, {
+          "val" : "Reactome:REACT_113271"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "adenosine 5'-triphosphatase activity",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "ATP hydrolase activity",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "adenosinetriphosphatase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "ATP phosphohydrolase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "ATP monophosphatase activity",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "adenosine triphosphatase activity",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "SV40 T-antigen",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "(Ca2+ + Mg2+)-ATPase",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "complex V (mitochondrial electron transport)",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "HCO3--ATPase",
+          "xrefs" : [ "EC:3.6.1.3" ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0004002"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ATPase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016766",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0016765"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0044404",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0044403"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030154",
+      "meta" : {
+        "definition" : {
+          "val" : "The process in which relatively unspecialized cells, e.g. embryonic or regenerative cells, acquire specialized structural and/or functional features that characterize the cells, tissues, or organs of the mature organism or some other relatively stable phase of the organism's life history. Differentiation includes the processes involved in commitment of a cell to a specific fate and its subsequent development to the mature state.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Cellular_differentiation"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell differentiation"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0000988",
+      "meta" : {
+        "definition" : {
+          "val" : "Interacting selectively and non-covalently with any protein or protein complex (a complex of two or more proteins that may include other nonprotein molecules), in order to modulate transcription. A protein binding transcription factor may or may not also interact with the template nucleic acid (either DNA or RNA) as well.",
+          "xrefs" : [ "GOC:txnOH" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_manually_annotate" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "protein binding transcription factor activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "transcription factor activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2010-08-10T04:03:22Z"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term is in the subset of terms that should not be used for direct gene product annotation. This term does not provide specificity with respect to the type of protein binding, e.g. transcription factor binding or RNA polymerase binding. Please use a child term that provides that specificity or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation QC."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "kchris"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transcription factor activity, protein binding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gocheck_do_not_manually_annotate",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Term not to be used for direct manual annotation"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005768",
+      "meta" : {
+        "definition" : {
+          "val" : "A vacuole to which materials ingested by endocytosis are delivered.",
+          "xrefs" : [ "ISBN:0198506732", "PMID:19696797" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Endosome"
+        }, {
+          "val" : "NIF_Subcellular:sao1720343330"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "endosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005886",
+      "meta" : {
+        "definition" : {
+          "val" : "The membrane surrounding a cell that separates the cell from its external environment. It consists of a phospholipid bilayer and associated proteins.",
+          "xrefs" : [ "ISBN:0716731363" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida" ],
+        "xrefs" : [ {
+          "val" : "NIF_Subcellular:sao1663586795"
+        }, {
+          "val" : "Wikipedia:Cell_membrane"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "plasmalemma",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cell membrane",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "inner endospore membrane",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cellular membrane",
+          "xrefs" : [ "NIF_Subcellular:sao6433132645" ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "cytoplasmic membrane",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "plasma membrane lipid bilayer",
+          "xrefs" : [ "GOC:mah" ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "bacterial inner membrane",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasBroadSynonym",
+          "val" : "juxtamembrane",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0005904"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "plasma membrane"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0002376",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process involved in the development or functioning of the immune system, an organismal system for calibrated responses to potential internal or invasive threats.",
+          "xrefs" : [ "GOC:add", "GOC:mtg_15nov05", "GO_REF:0000022" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Immune_system"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+          "val" : "Note that this term is a direct child of 'biological_process ; GO:0008150' because some immune system processes are types of cellular process (GO:0009987), whereas others are types of multicellular organism process (GO:0032501). This term was added by GO_REF:0000022."
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "immune system process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0005764",
+      "meta" : {
+        "definition" : {
+          "val" : "A small lytic vacuole that has cell cycle-independent morphology and is found in most animal cells and that contains a variety of hydrolases, most of which have their maximal activities in the pH range 5-6. The contained enzymes display latency if properly isolated. About 40 different lysosomal hydrolases are known and lysosomes have a great variety of morphologies and functions.",
+          "xrefs" : [ "GOC:mah", "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant" ],
+        "xrefs" : [ {
+          "val" : "Wikipedia:Lysosome"
+        }, {
+          "val" : "NIF_Subcellular:sao585356902"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "cellular_component"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "lysosome"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007148",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0000902"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007267",
+      "meta" : {
+        "definition" : {
+          "val" : "Any process that mediates the transfer of information from one cell to another. This process includes signal transduction in the receiving cell and, where applicable, release of a ligand and any processes that actively facilitate its transport and presentation to the receiving cell.  Examples include signaling via soluble ligands, via cell adhesion molecules and via gap junctions.",
+          "xrefs" : [ "GOC:dos", "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_plant", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cell-cell signalling",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cell-cell signaling"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007025",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006457"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0043566",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0003677"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007024",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006457"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0008233",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the hydrolysis of a peptide bond. A peptide bond is a covalent bond formed when the carbon atom from the carboxyl group of one amino acid shares electrons with the nitrogen atom from the amino group of a second amino acid.",
+          "xrefs" : [ "GOC:jl", "ISBN:0815332181" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida" ],
+        "xrefs" : [ {
+          "val" : "Reactome:REACT_19284"
+        }, {
+          "val" : "Reactome:REACT_99630"
+        }, {
+          "val" : "Reactome:REACT_13710"
+        }, {
+          "val" : "Reactome:REACT_106748"
+        }, {
+          "val" : "Reactome:REACT_110349"
+        }, {
+          "val" : "EC:3.4"
+        }, {
+          "val" : "Reactome:REACT_93020"
+        } ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "protease activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "proteinase activity",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "hydrolase, acting on peptide bonds",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "peptide hydrolase activity",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "peptidase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0042592",
+      "meta" : {
+        "definition" : {
+          "val" : "Any biological process involved in the maintenance of an internal steady state.",
+          "xrefs" : [ "GOC:jl", "ISBN:0395825172" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_agr", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_mouse", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl" ],
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "negative regulation of homeostatic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "homeostasis",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "activation of homeostatic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasNarrowSynonym",
+          "val" : "inhibition of homeostatic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "regulation of homeostatic process",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "positive regulation of homeostatic process",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0032846"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0032844"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:0032845"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "homeostatic process"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0007022",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006457"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0030705",
+      "meta" : {
+        "definition" : {
+          "val" : "The directed movement of substances along cytoskeletal fibers such as microfilaments or microtubules within a cell.",
+          "xrefs" : [ "GOC:mah" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic" ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cytoskeleton-dependent intracellular transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0016779",
+      "meta" : {
+        "definition" : {
+          "val" : "Catalysis of the transfer of a nucleotidyl group to a reactant.",
+          "xrefs" : [ "ISBN:0198506732" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_metagenomics", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_candida", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_aspergillus" ],
+        "xrefs" : [ {
+          "val" : "EC:2.7.7"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "molecular_function"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "nucleotidyltransferase activity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0015563",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0022857"
+        }, {
+          "pred" : "http://www.w3.org/2002/07/owl#deprecated",
+          "val" : "true"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ]
+      },
+      "type" : "CLASS"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#SubsetProperty",
+      "type" : "PROPERTY",
+      "lbl" : "subset_property"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0051186",
+      "meta" : {
+        "definition" : {
+          "val" : "The chemical reactions and pathways involving a cofactor, a substance that is required for the activity of an enzyme or other protein. Cofactors may be inorganic, such as the metal atoms zinc, iron, and copper in certain forms, or organic, in which case they are referred to as coenzymes. Cofactors may either be bound tightly to active sites or bind loosely with the substrate.",
+          "xrefs" : [ "GOC:ai" ]
+        },
+        "subsets" : [ "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_generic", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pir", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_chembl", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_pombe", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#gosubset_prok", "http://purl.obolibrary.org/obo/go/subsets/goslim_generic#goslim_yeast" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "cofactor metabolism",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "cofactor metabolic process"
+    } ],
+    "edges" : [ {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005622",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005635",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006914",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0009056"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0043167",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005730",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0019899",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0032991",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0050877",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0004871",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0007165"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008289",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003013",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005615",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005576"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005737",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006629",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007165",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003700",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0051301",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005811",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007267",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005739",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003735",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005198"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0022607",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000228",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005694"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005694",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009579",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006412",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0009058"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005654",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000988",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005975",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005623",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005815",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016791",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0042393",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0032196",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008168",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016301",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006520",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0044281"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006259",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0034641"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008135",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006412"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006790",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0022857",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0055085"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006091",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0140014",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008219",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006950",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005768",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0031410"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005578",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0051604",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0048646",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000229",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005694"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030533",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003723"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0015979",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005634",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0042592",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030533",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006412"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009056",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000988",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000051",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005764",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005773"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006397",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0034641"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000003",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0004518",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005856",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006412",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0034641"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008233",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016791",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005615",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006605",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006810",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0065003",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0022607"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000278",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0007049"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030234",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0034655",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0034641"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/RO_0002212",
+      "pred" : "subPropertyOf",
+      "obj" : "http://purl.obolibrary.org/obo/RO_0002211"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0048856",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007034",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000988",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016757",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0051082",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008135",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003723"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005739",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005737",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007009",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0061024"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0071941",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005794",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005886",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0019843",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003723"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005886",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005623"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016829",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006913",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000066",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009536",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0044403",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003924",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005777",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005840",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006913",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005773",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000228",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005634"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005618",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0030312"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005815",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005856"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/RO_0002213",
+      "pred" : "subPropertyOf",
+      "obj" : "http://purl.obolibrary.org/obo/RO_0002211"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0019748",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005576",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009058",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0004871",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006399",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0034641"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008283",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016301",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0043226",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005578",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005576"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003677",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005635",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005634"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007005",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007165",
+      "pred" : "http://purl.obolibrary.org/obo/RO_0002211",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008168",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007049",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0034330",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008565",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0051604",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0004386",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006605",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0040007",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006914",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000051",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0055085"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006605",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000066",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008134",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005783",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016853",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0061024",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0031410",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016746",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000902",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0048856"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030674",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006464",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003700",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0022618",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0065003"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005694",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0034641",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009536",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007010",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030234",
+      "pred" : "http://purl.obolibrary.org/obo/RO_0002211",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016192",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005811",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008092",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0022857",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/RO_0002092",
+      "pred" : "subPropertyOf",
+      "obj" : "http://purl.obolibrary.org/obo/RO_0002093"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0004518",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0034641"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005929",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005623"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000278",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000051",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0140014"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0140014",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0000278"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016810",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0071554",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005622",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005623"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0055085",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007568",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005829",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030312",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005623"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030705",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008565",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003729",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003723"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006397",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0043473",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000229",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005198",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006412",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0048870",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0040011"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0040011",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030705",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016765",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009579",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030705",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000066",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005622"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016491",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030555",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003723"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007155",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0042254",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005856",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0000902",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0044281",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0032182",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0051276",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005829",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0048646",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0048856"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0031410",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "pred" : "inverseOf",
+      "obj" : "http://purl.obolibrary.org/obo/BFO_0000051"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005634",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005929",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000051",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0032991"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005794",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005623"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007009",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030312",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005575"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005840",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0032991"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0022607",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016779",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0051186",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005783",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006457",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0008233",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030154",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030234",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0034655",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0009056"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0021700",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0030198",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005840",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0048870",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007165",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005777",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005737"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005654",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005634"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005730",
+      "pred" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0005634"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005773",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016887",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0006913",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0006810"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0009790",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0048856"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0003723",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016491",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0005929",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0043226"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0007059",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016874",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0016798",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0003674"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/GO_0002376",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/GO_0008150"
+    } ],
+    "id" : "http://purl.obolibrary.org/obo/go/subsets/goslim_generic.owl",
+    "meta" : {
+      "subsets" : [ ],
+      "xrefs" : [ ],
+      "basicPropertyValues" : [ {
+        "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion",
+        "val" : "1.2"
+      } ]
+    },
+    "equivalentNodesSets" : [ ],
+    "logicalDefinitionAxioms" : [ {
+      "definedClassId" : "http://purl.obolibrary.org/obo/GO_0000278",
+      "genusIds" : [ "http://purl.obolibrary.org/obo/GO_0007049" ],
+      "restrictions" : [ {
+        "propertyId" : "http://purl.obolibrary.org/obo/BFO_0000051",
+        "fillerId" : "http://purl.obolibrary.org/obo/GO_0140014"
+      } ]
+    }, {
+      "definedClassId" : "http://purl.obolibrary.org/obo/GO_0004871",
+      "genusIds" : [ "http://purl.obolibrary.org/obo/GO_0003674" ],
+      "restrictions" : [ {
+        "propertyId" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "fillerId" : "http://purl.obolibrary.org/obo/GO_0007165"
+      } ]
+    }, {
+      "definedClassId" : "http://purl.obolibrary.org/obo/GO_0000228",
+      "genusIds" : [ "http://purl.obolibrary.org/obo/GO_0005694" ],
+      "restrictions" : [ {
+        "propertyId" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "fillerId" : "http://purl.obolibrary.org/obo/GO_0005634"
+      } ]
+    }, {
+      "definedClassId" : "http://purl.obolibrary.org/obo/GO_0000229",
+      "genusIds" : [ "http://purl.obolibrary.org/obo/GO_0005694" ],
+      "restrictions" : [ {
+        "propertyId" : "http://purl.obolibrary.org/obo/BFO_0000050",
+        "fillerId" : "http://purl.obolibrary.org/obo/GO_0005737"
+      } ]
+    } ],
+    "domainRangeAxioms" : [ ],
+    "propertyChainAxioms" : [ {
+      "predicateId" : "http://purl.obolibrary.org/obo/BFO_0000066",
+      "chainPredicateIds" : [ "http://purl.obolibrary.org/obo/BFO_0000066", "http://purl.obolibrary.org/obo/BFO_0000050" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/RO_0002213",
+      "chainPredicateIds" : [ "http://purl.obolibrary.org/obo/RO_0002212", "http://purl.obolibrary.org/obo/RO_0002212" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/RO_0002211",
+      "chainPredicateIds" : [ "http://purl.obolibrary.org/obo/RO_0002211", "http://purl.obolibrary.org/obo/BFO_0000050" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/RO_0002213",
+      "chainPredicateIds" : [ "http://purl.obolibrary.org/obo/RO_0002213", "http://purl.obolibrary.org/obo/BFO_0000050" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/RO_0002212",
+      "chainPredicateIds" : [ "http://purl.obolibrary.org/obo/RO_0002212", "http://purl.obolibrary.org/obo/BFO_0000050" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/BFO_0000066",
+      "chainPredicateIds" : [ "http://purl.obolibrary.org/obo/BFO_0000050", "http://purl.obolibrary.org/obo/BFO_0000066" ]
+    } ]
+  } ]
+}

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,0 +1,41 @@
+import pytest
+
+from ontobio.io import qc
+from ontobio import ontol_factory
+
+ontology = ontol_factory.OntologyFactory().create("tests/resources/goslim_generic.json")
+
+def make_annotation(goid, evidence):
+    annotation = ["blah", "blah", "blah", "blah", goid, "blah", evidence]
+    return annotation
+
+def test_result():
+    assert qc.result(True, qc.FailMode.HARD) == qc.ResultType.PASS
+    assert qc.result(False, qc.FailMode.HARD) == qc.ResultType.ERROR
+    assert qc.result(False, qc.FailMode.SOFT) == qc.ResultType.WARNING
+
+def test_go_rule08():
+    # pass
+    a = make_annotation("GO:0006397", "ANY")
+    test_result = qc.GoRule08().test(a, ontology)
+    assert test_result.result_type == qc.ResultType.PASS
+
+    # fail with manual evidence and do_not_manually_annotate
+    a = make_annotation("GO:0006950", "ANY")
+    test_result = qc.GoRule08().test(a, ontology)
+    assert test_result.result_type == qc.ResultType.ERROR
+
+    a = make_annotation("GO:0006810", "IEA")
+    test_result = qc.GoRule08().test(a, ontology)
+    assert test_result.result_type == qc.ResultType.ERROR
+
+def test_all_rules():
+    # pass
+    a = make_annotation("GO:0006397", "ANY")
+    test_results = qc.test_go_rules(a, ontology)
+    assert len(test_results.keys()) == 1
+    assert test_results["GORULE:0000008"].result_type == qc.ResultType.PASS
+
+
+if __name__ == "__main__":
+    pytest.main(args=["tests/test_qc.py"])


### PR DESCRIPTION
For https://github.com/biolink/ontobio/issues/154 and the future.

This provides an easy way to implement go rules that act on an annotation by annotation level to be checked by the gaf parser. This model can be extended if needed to other kinds of rule checks. The triggering of the QC in the gaf parser is small and easy to use. 

To add a Go Rule, just make a class like the GoRule08 existing example. This slightly mirrors the rule json format in go-site. 