### PR TITLE
throwing out lines with GO_REF:33 in the references column

### DIFF
--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -129,6 +129,12 @@ class GafParser(assocparser.AssocParser):
                                 msg="Expecting a known ECO GAF code, e.g ISS")
                 return assocparser.ParseResult(line, [], True)
 
+        # Throw out the line if it uses GO_REF:0000033, see https://github.com/geneontology/go-site/issues/563#event-1519351033
+        if "GO_REF:0000033" in reference.split("|"):
+            self.report.error(line, assocparser.Report.INVALID_ID, reference,
+                                msg="Disallowing GO_REF:0000033 in reference field as of 03/13/2018")
+            return assocparser.ParseResult(line, [], True)
+
         # validation
         self._validate_symbol(db_object_symbol, line)
 

--- a/tests/resources/errors.gaf
+++ b/tests/resources/errors.gaf
@@ -25,3 +25,5 @@ PomBase	SPAC25B8.17	ypf1		GO:0000005	GO_REF:0000024	MADEUP	SGD:S000001583	C	intr
 PomBase	SPAC25B8.17	ypf1		GO:0000006	GO_REF:0000024	ISO	SGD:S000001583	C	intramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)	ppp81	protein	taxon:4896	2015-03-05	PomBase	foo(X:1)
 ! Bad date, unparsable
 PomBase	SPAC25B8.17	ypf1		GO:0000007	GO_REF:0000024	ISO	SGD:S000001583	C	intramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)	ppp81	protein	taxon:4896	TODAY	PomBase	foo(X:1)
+! GO_REF:0000033 no longer allowed
+PomBase	SPAC25B8.17	ypf1		GO:0000007	GO_REF:0000033	ISO	SGD:S000001583	C	intramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)	ppp81	protein	taxon:4896	20180313	PomBase	foo(X:1)

--- a/tests/test_gafparser.py
+++ b/tests/test_gafparser.py
@@ -192,7 +192,7 @@ def test_errors_gaf():
     print("MESSAGES: {}".format(len(msgs)))
     for m in msgs:
         print("MESSAGE: {}".format(m))
-    assert len(msgs) == 15
+    assert len(msgs) == 16
 
     # we expect 7
     assert len(assocs) == 7


### PR DESCRIPTION
For https://github.com/geneontology/go-site/issues/563