### PR TITLE
Include result hits as 'numFound' in payload returned by GolrSearchQuery and GolrAssociationQuery

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -388,6 +388,7 @@ class GolrSearchQuery(GolrAbstractQuery):
         payload = {
             'facet_counts': translate_facet_field(fcs),
             'pagination': {},
+            'numFound': results.hits,
             'highlighting': results.highlighting,
             'docs': results.docs
         }
@@ -929,7 +930,8 @@ class GolrAssociationQuery(GolrAbstractQuery):
 
         payload = {
             'facet_counts': translate_facet_field(fcs),
-            'pagination': {}
+            'pagination': {},
+            'numFound': results.hits
         }
 
         include_raw=self.include_raw


### PR DESCRIPTION
Add `numFound` into the response payload such that its available for association queries made by the biolink-api.

This PR aims to fix https://github.com/biolink/biolink-api/issues/155

@cmungall @putmantime
