### PR TITLE
Use correct go_context jsonld file in gaf->go-cam

### DIFF
--- a/notebooks/Phenotype_Enrichment.ipynb
+++ b/notebooks/Phenotype_Enrichment.ipynb
@@ -589,7 +589,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/ontobio/rdfgen/assoc_rdfgen.py
+++ b/ontobio/rdfgen/assoc_rdfgen.py
@@ -20,7 +20,10 @@ ro = OboRO()
 evt = Evidence()
 upt = UpperLevel()
 
-prefix_context = {key: value for context in curie_util.default_curie_maps + [curie_util.read_biocontext("minerva_context")] for key, value in context.items()}
+# Pull the go_context file from prefixcommons.
+# NOTE: this is a temporary measure. We will build the go json ld context as part of the pipeline in future
+# See https://github.com/geneontology/go-site/issues/617
+prefix_context = {key: value for context in curie_util.default_curie_maps + [curie_util.read_biocontext("go_context")] for key, value in context.items()}
 
 HAS_SUPPORTING_REFERENCE = URIRef(expand_uri(evt.has_supporting_reference, cmaps=[evt._prefixmap]))
 


### PR DESCRIPTION
NOTE: this is a temporary measure. We will build the go json ld context as part of the pipeline in future
See https://github.com/geneontology/go-site/issues/617