### PR TITLE
Invert subject and object from Solr results when invert_subject_object=true

### DIFF
--- a/ontobio/golr/golr_associations.py
+++ b/ontobio/golr/golr_associations.py
@@ -293,10 +293,10 @@ def calculate_information_content(**kwargs):
 
 from ontobio.vocabulary.relations import HomologyTypes
 
-def get_homologs(gene, relation=HomologyTypes.Ortholog.value):
-    search_associations(subject_category='gene',
+def get_homologs(gene, relation=HomologyTypes.Ortholog.value, **kwargs):
+    return search_associations(subject_category='gene',
                         object_category='gene',
                         relation=relation,
-                        subject=gene)
-                        
-    
+                        subject=gene,
+                        **kwargs)
+


### PR DESCRIPTION
When `invert_subject_object=True`, the Solr query is made after inverting the subject and the object, but the results from Solr are not parsed properly.

This PR aims at ensuring that the subject and object ordering is maintained in the response parsed from Solr results.

Required for biolink/biolink-api#143