### PR TITLE
Paintmerge 591

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -1,0 +1,385 @@
+import click
+import json
+import os
+import yaml
+import requests
+import gzip
+import urllib
+import re
+
+from functools import wraps
+
+from ontobio.ontol_factory import OntologyFactory
+from ontobio.io.gafparser import GafParser
+from ontobio.io.assocwriter import GafWriter
+from ontobio.io.assocwriter import GpadWriter
+from ontobio.io import assocparser
+from ontobio.io import gafgpibridge
+from ontobio.io import entitywriter
+from ontobio.rdfgen import assoc_rdfgen
+
+
+from typing import Dict
+
+def thispath():
+    os.path.normpath(os.path.abspath(__file__))
+
+def gzips(file_function):
+
+    @wraps(file_function)
+    def wrapper(*args, **kwargs):
+        output_file = file_function(*args, **kwargs)
+        if isinstance(output_file, list):
+            for o in output_file:
+                zipup(o)
+        else:
+            zipup(output_file)
+
+        return output_file
+
+    return wrapper
+
+def zipup(file_path):
+    click.echo("Zipping {}".format(file_path))
+    path, filename = os.path.split(file_path)
+    zipname = "{}.gz".format(filename)
+    target = os.path.join(path, zipname)
+
+    with open(file_path, "rb") as p:
+        with gzip.open(target, "wb") as tf:
+                    tf.write(p.read())
+
+def find(l, finder):
+    filtered = [n for n in l if finder(n)]
+    if len(filtered) == 0:
+        return None
+    else:
+        return filtered[0]
+
+def metadata_file(metadata, group) -> Dict:
+    metadata_yaml = os.path.join(metadata, "datasets", "{}.yaml".format(group))
+    try:
+        with open(metadata_yaml, "r") as group_data:
+            click.echo("Found {group} metadata at {path}".format(group=group, path=metadata_yaml))
+            return yaml.load(group_data)
+    except Exception as e:
+        raise click.ClickException("Could not find or read {}: {}".format(metadata_yaml, str(e)))
+
+
+def download_source_gafs(group_metadata, target_dir, exclusions=[]):
+    gaf_urls = { data["dataset"]: data["source"] for data in group_metadata["datasets"] if data["type"] == "gaf" and data["dataset"] not in exclusions }
+
+    downloaded_paths = {}
+    for dataset, gaf_url in gaf_urls.items():
+        path = os.path.join(target_dir, "groups", group_metadata["id"], "{}-src.gaf.gz".format(dataset))
+        os.makedirs(os.path.split(path)[0], exist_ok=True)
+
+        click.echo("Downloading source gaf to {}".format(path))
+        if urllib.parse.urlparse(gaf_url)[0] == "ftp":
+            urllib.request.urlretrieve(gaf_url, path)
+        else:
+            response = requests.get(gaf_url, stream=True)
+            content_length = int(response.headers.get("Content-Length", None))
+
+            with open(path, "wb") as downloaded:
+                with click.progressbar(iterable=response.iter_content(chunk_size=512 * 1024), length=content_length, show_percent=True) as chunks:
+                    for chunk in chunks:
+                        if chunk:
+                            downloaded.write(chunk)
+
+        downloaded_paths[dataset] = path
+
+    return downloaded_paths
+
+def check_and_download_paint_source(paint_metadata, group_id, dataset, target_dir):
+    paint_dataset = find(paint_metadata["datasets"], lambda d: d["dataset"] == "paint_{}".format(dataset))
+    if paint_dataset is None:
+        return None
+
+    path = os.path.join(target_dir, "groups", group_id, "{}-src.gaf.gz".format(paint_dataset["dataset"]))
+    click.echo("Downloading paint to {}".format(path))
+    urllib.request.urlretrieve(paint_dataset["source"], path)
+    unzipped = os.path.join(os.path.split(path)[0], "{}-src.gaf".format(paint_dataset["dataset"]))
+    unzip(path, unzipped)
+    return unzipped
+
+
+def unzip(path, target):
+    click.echo("Unzipping {}".format(path))
+    def chunk_gen():
+        with gzip.open(path, "rb") as p:
+            while True:
+                chunk = p.read(size=512 * 1024)
+                if not chunk:
+                    break
+                yield chunk
+
+    with open(target, "wb") as tf:
+        with click.progressbar(iterable=chunk_gen()) as chunks:
+            for chunk in chunks:
+                tf.write(chunk)
+@gzips
+def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None):
+    filtered_associations = open(os.path.join(os.path.split(source_gaf)[0], "{}_noiea.gaf".format(dataset)), "w")
+
+    config = assocparser.AssocParserConfig(
+        ontology=ontology_graph,
+        filter_out_evidence=["IEA"],
+        filtered_evidence_file=filtered_associations,
+        gpi_authority_path=gpipath
+    )
+    validated_gaf_path = os.path.join(os.path.split(source_gaf)[0], "{}_valid.gaf".format(dataset))
+    outfile = open(validated_gaf_path, "w")
+    gafwriter = GafWriter(file=outfile)
+
+    click.echo("Validating source GAF: {}".format(source_gaf))
+    parser = GafParser(config=config)
+    with open(source_gaf) as sg:
+        lines = sum(1 for line in sg)
+
+    with open(source_gaf) as gaf:
+        with click.progressbar(iterable=parser.association_generator(file=gaf), length=lines) as associations:
+            for assoc in associations:
+                gafwriter.write_assoc(assoc)
+
+    outfile.close()
+    filtered_associations.close()
+
+    with open(os.path.join(os.path.split(source_gaf)[0], "{}.report.md".format(dataset)), "w") as report_md:
+        report_md.write(parser.report.to_markdown())
+
+    with open(os.path.join(os.path.split(source_gaf)[0], "{}.report.json".format(dataset)), "w") as report_json:
+        report_json.write(json.dumps(parser.report.to_report_json()))
+
+    return [validated_gaf_path, filtered_associations.name]
+
+# @gzips
+# def produce_gpi(dataset, target_dir, ontology_graph):
+#
+#     def conversion_gen(gaf_file, gafparser):
+#         cache = []
+#         for association in gafparser.association_generator(file=gaf_file):
+#             entity = bridge.convert_association(association)
+#             if entity not in cache:
+#                 cache.append(entity)
+#                 yield entity
+#             else:
+#                 continue
+#
+#     click.echo("No GPI in metadata, building from GAF")
+#     gaf_path = os.path.join(target_dir, "groups", dataset, "{}.gaf".format(dataset))
+#     gafparser = GafParser()
+#     gafparser.config = assocparser.AssocParserConfig(
+#         ontology=ontology_graph
+#     )
+#     bridge = gafgpibridge.GafGpiBridge()
+#     gpi_path = os.path.join(target_dir, "groups", dataset, "{}.gpi".format(dataset))
+#
+#     with open(gaf_path) as sg:
+#         lines = sum(1 for line in sg)
+#
+#     with open(gaf_path) as gf:
+#         with open(gpi_path, "w") as gpifile:
+#             gpiwriter = entitywriter.GpiWriter(file=gpifile)
+#             with click.progressbar(iterable=conversion_gen(gf, gafparser)) as entities:
+#                 for entity in entities:
+#                     if entity is not None:
+#                         gpiwriter.write_entity(entity)
+#
+#     return gpi_path
+
+@gzips
+def make_products(dataset, target_dir, gaf_path, products, ontology_graph):
+    gafparser = GafParser()
+    gafparser.config = assocparser.AssocParserConfig(
+        ontology=ontology_graph
+    )
+
+    with open(gaf_path) as sg:
+        lines = sum(1 for line in sg)
+
+    product_files = {
+        "gpad": open(os.path.join(os.path.split(gaf_path)[0], "{}.gpad".format(dataset)), "w"),
+        "gpi": open(os.path.join(os.path.split(gaf_path)[0], "{}.gpi".format(dataset)), "w")
+    }
+
+    # def write_gpi_entity(association, bridge, gpiwriter):
+    with open(gaf_path) as gf:
+        # gpi info:
+        click.echo("Using {} as the gaf to build data products with".format(gaf_path))
+        if products["gpi"]:
+            click.echo("Setting up {}".format(product_files["gpi"].name))
+            bridge = gafgpibridge.GafGpiBridge()
+            gpiwriter = entitywriter.GpiWriter(file=product_files["gpi"])
+            gpi_cache = []
+
+        if products["gpad"]:
+            click.echo("Setting up {}".format(product_files["gpad"].name))
+            gpadwriter = GpadWriter(file=product_files["gpad"])
+
+        click.echo("Making products...")
+        with click.progressbar(iterable=gafparser.association_generator(file=gf), length=lines) as associations:
+            for association in associations:
+                if products["gpi"]:
+                    entity = bridge.convert_association(association)
+                    if entity not in gpi_cache and entity is not None:
+                        gpi_cache.append(entity)
+                        gpiwriter.write_entity(entity)
+
+                if products["gpad"]:
+                    gpadwriter.write_assoc(association)
+
+        # After we run through associations
+        for f in product_files.values():
+            f.close()
+
+    return [product_files["gpad"].name, product_files["gpi"].name]
+
+@gzips
+def produce_ttl(dataset, target_dir, gaf_path, ontology_graph):
+    gafparser = GafParser()
+    gafparser.config = assocparser.AssocParserConfig(
+        ontology=ontology_graph
+    )
+
+    with open(gaf_path) as sg:
+        lines = sum(1 for line in sg)
+
+    ttl_path = os.path.join(os.path.split(gaf_path)[0], "{}_cam.ttl".format(dataset))
+    click.echo("Producing ttl: {}".format(ttl_path))
+    rdf_writer = assoc_rdfgen.TurtleRdfWriter()
+    transformer = assoc_rdfgen.CamRdfTransform(writer=rdf_writer)
+    parser_config = assocparser.AssocParserConfig(ontology=ontology_graph)
+
+    with open(gaf_path) as gf:
+        with click.progressbar(iterable=gafparser.association_generator(file=gf), length=lines) as associations:
+            for association in associations:
+                if "header" not in association or not association["header"]:
+                    transformer.provenance()
+                    transformer.translate(association)
+
+    with open(ttl_path, "wb") as ttl:
+        click.echo("Writing ttl to disk")
+        rdf_writer.serialize(destination=ttl)
+
+    return ttl_path
+
+@gzips
+def merge_mod_and_paint(mod_gaf_path, paint_gaf_path):
+
+    def header_and_annotations(gaf_file):
+        headers = []
+        annotations = []
+
+        for line in gaf_file.readlines():
+            if line.startswith("!"):
+                headers.append(line)
+            else:
+                annotations.append(line)
+
+        return (headers, annotations)
+
+    def make_paint_header(header, filename: str):
+        return ["! merged_from " + os.path.basename(filename) + ": " + line.split("!")[1].strip() for line in header if not re.match("![\s]*gaf.?version", line) ]
+
+    dirs, name = os.path.split(mod_gaf_path)
+    merged_path = os.path.join(dirs, "{}.gaf".format(name.split("_")[0]))
+    click.echo("Merging paint into base annotations at {}".format(merged_path))
+    with open(mod_gaf_path) as mod, open(paint_gaf_path) as paint:
+        mod_header, mod_annotations = header_and_annotations(mod)
+        paint_header, paint_annotations = header_and_annotations(paint)
+
+        all_lines = mod_header + make_paint_header(paint_header, paint_gaf_path) + mod_annotations + paint_annotations
+
+        with open(merged_path, "w") as merged_file:
+            merged_file.write("\n".join(all_lines))
+
+    return merged_path
+
+
+@click.group()
+def cli():
+    pass
+
+@cli.command()
+@click.argument("group")
+@click.option("--metadata", "-m", type=click.Path(), required=True)
+@click.option("--gaf", default=True, is_flag=True)
+@click.option("--gpi", default=False, is_flag=True)
+@click.option("--gpad", default=False, is_flag=True)
+@click.option("--ttl", default=False, is_flag=True)
+@click.option("--target", "-t", type=click.Path(), required=True)
+@click.option("--ontology", "-o", type=click.Path(exists=True), required=False)
+@click.option("--exclude", "-x", multiple=True)
+def produce(group, metadata, gaf, gpi, gpad, ttl, target, ontology, exclude):
+    click.echo("Building {}".format(group))
+
+    products = {
+        "gaf": gaf,
+        "gpi": gpi,
+        "gpad": gpad,
+        "ttl": ttl
+    }
+    click.echo("Making products {}.".format(", ".join([key for key in products if products[key]])))
+    absolute_target = os.path.abspath(target)
+    os.makedirs(os.path.join(absolute_target, "groups"), exist_ok=True)
+    click.echo("Products will go in {}".format(absolute_target))
+    absolute_metadata = os.path.abspath(metadata)
+
+    group_metadata = metadata_file(absolute_metadata, group)
+    click.echo("Loading ontology: {}...".format(ontology))
+    ontology_graph = OntologyFactory().create(ontology)
+
+    source_gaf_zips = download_source_gafs(group_metadata, absolute_target, exclusions=exclude)
+    source_gafs = {zip_path: os.path.join(os.path.split(zip_path)[0], "{}.gaf".format(dataset)) for dataset, zip_path in source_gaf_zips.items()}
+    for source_zip, source_gaf in source_gafs.items():
+        unzip(source_zip, source_gaf)
+
+    paint_metadata = metadata_file(absolute_metadata, "paint")
+
+    if products["gaf"]:
+        for dataset in source_gaf_zips.keys():
+            gafzip = source_gaf_zips[dataset]
+            source_gaf = source_gafs[gafzip]
+            valid_gaf = produce_gaf(dataset, source_gaf, ontology_graph)[0]
+
+            [gpad, gpi] = make_products(dataset, absolute_target, valid_gaf, products, ontology_graph)
+
+            paint_src_gaf = check_and_download_paint_source(paint_metadata, group_metadata["id"], dataset, absolute_target)
+
+            end_gaf = valid_gaf
+            if paint_src_gaf is not None:
+                paint_gaf = produce_gaf("paint_{}".format(dataset), paint_src_gaf, ontology_graph, gpipath=gpi)[0]
+                end_gaf = merge_mod_and_paint(valid_gaf, paint_gaf)
+            else:
+                gafgz = "{}.gz".format(valid_gaf)
+                os.rename(gafgz, os.path.join(os.path.split(gafgz)[0], "{}.gaf.gz".format(dataset)))
+
+            if products["ttl"]:
+                produce_ttl(dataset, absolute_target, end_gaf, ontology_graph)
+
+
+@cli.command()
+@click.argument("group")
+@click.argument("dataset")
+@click.option("--metadata", "-m", type=click.Path(), required=True)
+@click.option("--target", type=click.Path(), required=True)
+@click.option("--ontology", type=click.Path(), required=True)
+def paint(group, dataset, metadata, target, ontology):
+    absolute_metadata = os.path.abspath(metadata)
+    absolute_target = os.path.abspath(target)
+    os.makedirs(os.path.join(absolute_target, "groups"), exist_ok=True)
+    paint_metadata = metadata_file(absolute_metadata, "paint")
+    paint_src_gaf = check_and_download_paint_source(paint_metadata, dataset, absolute_target)
+
+    click.echo("Loading ontology: {}...".format(ontology))
+    ontology_graph = OntologyFactory().create(ontology)
+
+    gpi_path = os.path.join(absolute_target, "groups", dataset, "{}.gpi".format(dataset))
+    click.echo("Using GPI at {}".format(gpi_path))
+    paint_gaf = produce_gaf("paint_{}".format(dataset), paint_src_gaf, ontology_graph, gpipath=gpi_path)
+
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -238,6 +238,7 @@ def merge_mod_and_paint(mod_gaf_path, paint_gaf_path):
         annotations = []
 
         for line in gaf_file.readlines():
+            line = line.rstrip("\n")
             if line.startswith("!"):
                 headers.append(line)
             else:

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -153,40 +153,6 @@ def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None):
 
     return [validated_gaf_path, filtered_associations.name]
 
-# @gzips
-# def produce_gpi(dataset, target_dir, ontology_graph):
-#
-#     def conversion_gen(gaf_file, gafparser):
-#         cache = []
-#         for association in gafparser.association_generator(file=gaf_file):
-#             entity = bridge.convert_association(association)
-#             if entity not in cache:
-#                 cache.append(entity)
-#                 yield entity
-#             else:
-#                 continue
-#
-#     click.echo("No GPI in metadata, building from GAF")
-#     gaf_path = os.path.join(target_dir, "groups", dataset, "{}.gaf".format(dataset))
-#     gafparser = GafParser()
-#     gafparser.config = assocparser.AssocParserConfig(
-#         ontology=ontology_graph
-#     )
-#     bridge = gafgpibridge.GafGpiBridge()
-#     gpi_path = os.path.join(target_dir, "groups", dataset, "{}.gpi".format(dataset))
-#
-#     with open(gaf_path) as sg:
-#         lines = sum(1 for line in sg)
-#
-#     with open(gaf_path) as gf:
-#         with open(gpi_path, "w") as gpifile:
-#             gpiwriter = entitywriter.GpiWriter(file=gpifile)
-#             with click.progressbar(iterable=conversion_gen(gf, gafparser)) as entities:
-#                 for entity in entities:
-#                     if entity is not None:
-#                         gpiwriter.write_entity(entity)
-#
-#     return gpi_path
 
 @gzips
 def make_products(dataset, target_dir, gaf_path, products, ontology_graph):

--- a/ontobio/__init__.py
+++ b/ontobio/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.3.0rc0'
+__version__ = '0.3.0rc1'
 
 from .ontol_factory import OntologyFactory
 from .ontol import Ontology, Synonym, TextDefinition

--- a/ontobio/__init__.py
+++ b/ontobio/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.3.0rc1'
+__version__ = '0.3.0rc2'
 
 from .ontol_factory import OntologyFactory
 from .ontol import Ontology, Synonym, TextDefinition

--- a/ontobio/__init__.py
+++ b/ontobio/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.3.0-rc'
+__version__ = '0.3.0rc0'
 
 from .ontol_factory import OntologyFactory
 from .ontol import Ontology, Synonym, TextDefinition

--- a/ontobio/__init__.py
+++ b/ontobio/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.2.37'
+__version__ = '0.3.0-rc'
 
 from .ontol_factory import OntologyFactory
 from .ontol import Ontology, Synonym, TextDefinition

--- a/ontobio/__init__.py
+++ b/ontobio/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.3.0rc2'
+__version__ = '0.3.0rc3'
 
 from .ontol_factory import OntologyFactory
 from .ontol import Ontology, Synonym, TextDefinition

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -57,7 +57,8 @@ class AssocParserConfig():
                  exclude_relations=[],
                  include_relations=[],
                  filter_out_evidence=[],
-                 filtered_evidence_file=None):
+                 filtered_evidence_file=None,
+                 gpi_authority_path=None):
 
         self.remove_double_prefixes=remove_double_prefixes
         self.ontology=ontology
@@ -70,6 +71,7 @@ class AssocParserConfig():
         self.exclude_relations=exclude_relations
         self.filter_out_evidence = filter_out_evidence
         self.filtered_evidence_file = filtered_evidence_file
+        self.gpi_authority_path = gpi_authority_path
 
 class Report():
     """

--- a/ontobio/io/assocwriter.py
+++ b/ontobio/io/assocwriter.py
@@ -83,11 +83,15 @@ class GpadWriter(AssocWriter):
     """
     def __init__(self, file=None):
         self.file = file
+        self._write("!gpa-version: 1.1\n")
 
     def write_assoc(self, assoc):
         """
         Write a single association to a line in the output file
         """
+        if assoc.get("header", False):
+            return
+
         subj = assoc['subject']
 
         db, db_object_id = self._split_prefix(subj)

--- a/ontobio/io/entitywriter.py
+++ b/ontobio/io/entitywriter.py
@@ -35,7 +35,7 @@ class EntityWriter():
         Write a single entity
         """
         pass  ## Implemented in subclasses
-    
+
     def write(self, entities, meta=None):
         """
         Write a complete set of entities to a file
@@ -50,30 +50,45 @@ class EntityWriter():
         """
         for e in entities:
             self.write_entity(e)
-        
+
 class GpiWriter(EntityWriter):
     """
     Writes entities in GPI format
+
+    Takes an entity dictionary:
+    {
+        'id': id, (String)
+        'label': db_object_symbol, (String)
+        'full_name': db_object_name, (String)
+        'synonyms': synonyms, (List[str])
+        'type': db_object_type, (String)
+        'parents': parents, (List[Str])
+        'xrefs': xref_ids, (List[Str])
+        'taxon': {
+            'id': self._taxon_id(taxon) (String)
+        }
+    }
     """
     def __init__(self, file=None):
         self.file = file
 
     def write_entity(self, entity):
         """
-        Write a single association to a line in the output file
+        Write a single entity to a line in the output file
         """
-        db, db_object_id = self._split_prefix(id)
+        db, db_object_id = self._split_prefix(entity)
 
-        vals = [db,
-                db_object_id,
-                entity.get('label'),
-                entity.get('full_name'),
-                entity.get('synonyms'),
-                entity.get('type'),
-                entity.get('taxon')['id'],
-                entity.get('parents'),
-                entity.get('xrefs'),
-                entity.get('properties')]
+        vals = [
+            db,
+            db_object_id,
+            entity.get('label'),
+            entity.get('full_name'),
+            entity.get('synonyms'),
+            entity.get('type'),
+            entity.get('taxon')['id'],
+            entity.get('parents'),
+            entity.get('xrefs'),
+            entity.get('properties')
+        ]
 
         self._write_row(vals)
-    

--- a/ontobio/io/gafgpibridge.py
+++ b/ontobio/io/gafgpibridge.py
@@ -1,0 +1,59 @@
+import json
+from typing import Dict, NewType, List
+
+Association = NewType("Association", dict)
+# Entity = NewType("Entity", dict)
+
+class Entity(dict):
+
+    def __init__(self, d):
+        super(Entity, self).__init__(d)
+
+    def __hash__(self):
+        id = self.get("id", 1).__hash__()
+        label = self.get("label", 1).__hash__()
+        name = self.get("full_name", 1).__hash__()
+        synonyms = self.get("synonyms", None)
+        synhash = 1
+        if synonyms is not None:
+            for i, syn in enumerate(synonyms):
+                synhash = 2 ** i * syn.__hash__() + synhash
+
+        t = self.get("type", 1)
+        taxon = self.get("taxon", 1).get("id", 1).__hash__()
+
+        return id * label * name * synhash * t * taxon
+
+
+
+class GafGpiBridge(object):
+
+    def __init__(self):
+        self.cache = []
+
+    def convert_association(self, association: Association) -> Entity:
+        """
+        'id' is already `join`ed in both the Association and the Entity,
+        so we don't have to worry about what that looks like. We assume
+        it's correct.
+        """
+        if "header" not in association or association["header"] == False:
+            # print(json.dumps(association, indent=4))
+            gpi_obj = {
+                'id': association["subject"]["id"],
+                'label': association["subject"]["label"],  # db_object_symbol,
+                'full_name': association["subject"]["fullname"],  # db_object_name,
+                'synonyms': association["subject"]["synonyms"],
+                'type': association["subject"]["type"], #db_object_type,
+                'parents': "", # GAF does not have this field, but it's optional in GPI
+                'xrefs': "", # GAF does not have this field, but it's optional in GPI
+                'taxon': {
+                    'id': association["subject"]["taxon"]["id"]
+                }
+            }
+            return gpi_obj
+
+        return None
+
+    def entities(self) -> List[Entity]:
+        return list(self.cache)

--- a/ontobio/ontol_factory.py
+++ b/ontobio/ontol_factory.py
@@ -36,7 +36,7 @@ class OntologyFactory():
 
     # class variable - reuse the same object throughout
     test = 0
-    
+
     def __init__(self, handle=None):
         """
         initializes based on an ontology name
@@ -66,15 +66,15 @@ class OntologyFactory():
         """
         if handle == None:
             self.test = self.test+1
-            logging.info("T: "+str(self.test))                
+            logging.info("T: "+str(self.test))
             global default_ontology
             if default_ontology == None:
                 logging.info("Creating new instance of default ontology")
                 default_ontology = create_ontology(default_ontology_handle)
-            logging.info("Using default_ontology")                
+            logging.info("Using default_ontology")
             return default_ontology
         return create_ontology(handle, **args)
-    
+
 #@cachier(stale_after=SHELF_LIFE)
 def create_ontology(handle=None, **args):
     ont = None
@@ -173,4 +173,3 @@ def translate_file_to_ontology(handle, **args):
             logging.info("using cached file: "+fn)
         g = obograph_util.convert_json_file(fn, **args)
         return Ontology(handle=handle, payload=g)
-    

--- a/ontobio/rdfgen/assoc_rdfgen.py
+++ b/ontobio/rdfgen/assoc_rdfgen.py
@@ -183,6 +183,10 @@ class CamRdfTransform(RdfTransform):
     See https://github.com/geneontology/minerva/blob/master/specs/owl-model.md
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bad_properties_found = set()
+
     def emit_header(self):
         if self._emit_header_done:
             return
@@ -255,7 +259,9 @@ class CamRdfTransform(RdfTransform):
                 self.emit_type(filler_inst, self.uri(ext['filler']))
                 p = self.lookup_relation(ext['property'])
                 if p is None:
-                    logging.warning("No such property {}".format(ext))
+                    if ext["property"] not in self.bad_properties_found:
+                        self.bad_properties_found.add(ext["property"])
+                        logging.warning("No such property {}".format(ext))
                 else:
                     self.emit(tgt_id, p, filler_inst)
         self.translate_evidence(association, aspect_triple)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setuptools.setup(
         'dev': ['plotly'],
         'test': ['pytest'],
     },
-    scripts=['bin/ogr.py', 'bin/ontobio-assoc.py', 'bin/ontobio-parse-assocs.py', 'bin/ontobio-lexmap.py', 'bin/rdfgen.py']
+    scripts=['bin/ogr.py', 'bin/ontobio-assoc.py', 'bin/ontobio-parse-assocs.py', 'bin/ontobio-lexmap.py', 'bin/rdfgen.py', 'bin/validate.py']
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.


### PR DESCRIPTION
The main change here is to add a validate.py script in the bin directory. This orchestrates much of what the old makefile did. You give validate the target directory, the metadata directory, and which group to produce data from:

First it finds the <group>.yaml. For each gaf dataset in the group yaml, download the source gaf, and run it through the gaf validation step, producing the noiea, and standard reports we all know and love. We call this <dataset>_valid.gaf.

Then we produce a gpi file and a gpad file from the validated gaf.

Next we check if there is a corresponding paint_<group> dataset. If so, we download the src paint gaf, validate it, but use the earlier GPI to correct entitites in the paint gaf. 

Once we have a valdiated paint gaf, we do the "merge", where we take validated paint gaf and just paste it on the bottom of the standard validated gaf. This is then the final <dataset>.gaf product. 

Then we produce a ttl on this final gaf product. 

Along the way, each file is zipped.

There are few outside changes to ontobio, but they're few. Travis tests pass. I have a test branch in go-site where I have a new makefile that uses this ontobio. Before we can do a real jenkins test on the iteration branch, we will probably have to merge and release this, yes?