### PR TITLE
increase version of prefixcommons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # -e .
 marshmallow==3.0.0b3
 jsobject>=0.0
-prefixcommons>=0.1.4
+prefixcommons>=0.1.6
 requests>=0.0
 pip>=9.0.1
 wheel>0.25.0


### PR DESCRIPTION
This ensures that by default shortest URIs are chosen if multiple
contractions are possible