### PR TITLE
Explicitly flag errors and skip lines if local id or idspace not set

### DIFF
--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -3,7 +3,7 @@ import logging
 import json
 
 from ontobio.io import assocparser
-from ontobio.io.assocparser import ENTITY, EXTENSION, ANNOTATION
+from ontobio.io.assocparser import ENTITY, EXTENSION, ANNOTATION, Report
 from ontobio.io import qc
 from ontobio.io import entityparser
 from ontobio.io import entitywriter
@@ -126,6 +126,17 @@ class GafParser(assocparser.AssocParser):
          annotation_xp,
          gene_product_isoform] = vals
 
+        ## check for missing columns
+        if db == "":
+            self.report.error(line, Report.INVALID_IDSPACE, "EMPTY", "col1 is empty")
+            return assocparser.ParseResult(line, [], True)
+        if db_object_id == "":
+            self.report.error(line, Report.INVALID_ID, "EMPTY", "col2 is empty")
+            return assocparser.ParseResult(line, [], True)
+        if taxon == "":
+            self.report.error(line, Report.INVALID_TAXON, "EMPTY", "taxon column is empty")
+            return assocparser.ParseResult(line, [], True)
+        
         ## --
         ## db + db_object_id. CARD=1
         ## --

--- a/tests/resources/errors.gaf
+++ b/tests/resources/errors.gaf
@@ -27,3 +27,5 @@ PomBase	SPAC25B8.17	ypf1		GO:0000006	GO_REF:0000024	ISO	SGD:S000001583	C	intrame
 PomBase	SPAC25B8.17	ypf1		GO:0000007	GO_REF:0000024	ISO	SGD:S000001583	C	intramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)	ppp81	protein	taxon:4896	TODAY	PomBase	foo(X:1)
 ! GO_REF:0000033 no longer allowed
 PomBase	SPAC25B8.17	ypf1		GO:0000007	GO_REF:0000033	ISO	SGD:S000001583	C	intramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)	ppp81	protein	taxon:4896	20180313	PomBase	foo(X:1)
+! empty col1 and col2
+		At2g28815		GO:0005762	PMID:21873635	IBA	PANTHER:PTN000259457|UniProtKB:Q9NX20|SGD:S000000134	C	60S ribosomal protein L16-like, mitochondrial	UniProtKB:Q84WZ8|PTN000259517	protein	taxon:3702	2017-02-28	GO_Central		

--- a/tests/test_gafparser.py
+++ b/tests/test_gafparser.py
@@ -1,3 +1,4 @@
+from ontobio.io import assocparser
 from ontobio.io.gpadparser import GpadParser
 from ontobio.io.gafparser import GafParser
 from ontobio.io import GafWriter
@@ -190,9 +191,13 @@ def test_errors_gaf():
     assocs = p.parse(open("tests/resources/errors.gaf","r"), skipheader=True)
     msgs = p.report.messages
     print("MESSAGES: {}".format(len(msgs)))
+    n_invalid_idspace = 0
     for m in msgs:
         print("MESSAGE: {}".format(m))
-    assert len(msgs) == 16
+        if m['type'] == assocparser.Report.INVALID_IDSPACE:
+            n_invalid_idspace += 1
+    assert len(msgs) == 17
+    assert n_invalid_idspace == 1
 
     # we expect 7
     assert len(assocs) == 7
@@ -211,6 +216,8 @@ def test_errors_gaf():
                 assert x['filler'] == 'X:1'
             assert len(xs) == 1
 
+            
+            
 def test_factory():
     afa = AssociationSetFactory()
     ont = OntologyFactory().create(ONT)


### PR DESCRIPTION
also for taxon
For context see https://github.com/geneontology/go-site/issues/639