### PR TITLE
Handle solr docs without a category

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -360,7 +360,7 @@ class GolrSearchQuery(GolrAbstractQuery):
 
         suffixes = ['std', 'kw', 'eng']
         if self.is_go:
-            self.search_fields=dict(entity_label=3,general_blob=3)
+            self.search_fields=dict(entity_label=3, general_blob=3)
             self.hl = False
             # TODO: formal mapping
             if 'taxon_label' in self.facet_fields:
@@ -425,7 +425,7 @@ class GolrSearchQuery(GolrAbstractQuery):
             if len(positive_filter) > 0:
                 or_filter = 'prefix:"{}"'.format(positive_filter[0])
                 for pfix_filter in positive_filter[1:]:
-                    or_filter += 'OR prefix:"{}"'.format(pfix_filter)
+                    or_filter += ' OR prefix:"{}"'.format(pfix_filter)
                 params['fq'].append(or_filter)
 
         if self.boost_fx is not None:
@@ -519,13 +519,16 @@ class GolrSearchQuery(GolrAbstractQuery):
             else:
                 hl = Highlight(None, None, None)
 
+            # In some cases a node does not have a category
+            category = doc['category'] if 'category' in doc else []
+
             doc['taxon'] = doc['taxon'] if 'taxon' in doc else ""
             doc['taxon_label'] = doc['taxon_label'] if 'taxon_label' in doc else ""
             doc = AutocompleteResult(
                 id=doc['id'],
                 label=doc['label'],
                 match=hl.match,
-                category=doc['category'],
+                category=category,
                 taxon=doc['taxon'],
                 taxon_label=doc['taxon_label'],
                 highlight=hl.highlight,

--- a/tests/unit/resources/solr/autocomplete-nocat-expect.json
+++ b/tests/unit/resources/solr/autocomplete-nocat-expect.json
@@ -1,0 +1,18 @@
+{
+   "docs":[
+      {
+         "category":[
+
+         ],
+         "has_highlight":true,
+         "highlight":"<em class=\"hilite\">foo</em>d",
+         "id":"CHEBI:33290",
+         "label":[
+            "food"
+         ],
+         "match":"food",
+         "taxon":"",
+         "taxon_label":""
+      }
+   ]
+}

--- a/tests/unit/resources/solr/autocomplete-nocat.json
+++ b/tests/unit/resources/solr/autocomplete-nocat.json
@@ -1,0 +1,45 @@
+
+{
+  "highlighting":{
+    "CHEBI:33290":{
+      "label_eng":[
+        "<em class=\"hilite\">foo</em>d"
+      ]
+    }
+  },
+  "response":{
+    "numFound":1,
+    "docs":[
+      {
+         "id_eng":"CHEBI:33290",
+         "score":59.425438,
+         "_version_":1599053609463447553,
+         "id":"CHEBI:33290",
+         "label_eng":[
+            "food"
+         ],
+         "leaf":true,
+         "label_std":[
+            "food"
+         ],
+         "label_kw":[
+            "food"
+         ],
+         "iri_std":"http://purl.obolibrary.org/obo/CHEBI_33290",
+         "label":[
+            "food"
+         ],
+         "iri":"http://purl.obolibrary.org/obo/CHEBI_33290",
+         "id_std":"CHEBI:33290",
+         "prefix":"CHEBI",
+         "edges":8,
+         "iri_eng":"http://purl.obolibrary.org/obo/CHEBI_33290",
+         "id_kw":"CHEBI:33290",
+         "iri_kw":"http://purl.obolibrary.org/obo/CHEBI_33290"
+      }
+   ],
+    "start":0,
+    "maxScore":66.13394
+  },
+  "responseHeader":{}
+}


### PR DESCRIPTION
Currently querying solr docs without a category returns a 500, for example:
https://api-dev.monarchinitiative.org/api/search/entity/autocomplete/foo?rows=20&start=0

This should be fixed upstream in scigraph or the solr loader, but in the meantime this should be handled by ontobio.