### PR TITLE
making sure all gaf cam models have rdfs:labels

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -181,7 +181,7 @@ def make_products(dataset, target_dir, gaf_path, products, ontology_graph):
         click.echo("Using {} as the gaf to build data products with".format(gaf_path))
         if products["ttl"]:
             click.echo("Setting up {}".format(product_files["ttl"].name))
-            rdf_writer = assoc_rdfgen.TurtleRdfWriter()
+            rdf_writer = assoc_rdfgen.TurtleRdfWriter(label=os.path.split(product_files["ttl"].name)[1] )
             transformer = assoc_rdfgen.CamRdfTransform(writer=rdf_writer)
             parser_config = assocparser.AssocParserConfig(ontology=ontology_graph)
 


### PR DESCRIPTION
I hadn't set the `label` to the filename of the incoming gaf for some reason. With it set, you can see in https://github.com/biolink/ontobio/blob/master/ontobio/rdfgen/assoc_rdfgen.py#L62 that with the label definitely set, we add an rdfs:label triple. 

Tested with a previously broken MGI, we get the label.