### PR TITLE
Adding taxon_restriction features (also required for new BioLink version)

### DIFF
--- a/ontobio/config.py
+++ b/ontobio/config.py
@@ -52,6 +52,7 @@ class ConfigSchema(Schema):
     default_solr_schema = fields.Str()
     ontologies = fields.List(fields.Nested(OntologyConfigSchema))
     categories = fields.List(fields.Nested(CategorySchema))
+    taxon_restriction = fields.List(fields.Str(description="taxon restriction"))
     use_amigo_for = fields.List(fields.Str(description="category to use amigo for"))
 
     @post_load
@@ -108,7 +109,8 @@ class Config():
                  ontologies = None,
                  categories = None,
                  default_solr_schema = None,
-                 use_amigo_for = "function"):
+                 use_amigo_for = "function",
+                 taxon_restriction = None):
         self.solr_assocs = solr_assocs
         self.amigo_solr_assocs = amigo_solr_assocs
         self.solr_search = solr_search
@@ -121,6 +123,7 @@ class Config():
         self.categories = categories
         self.default_solr_schema = default_solr_schema
         self.use_amigo_for = use_amigo_for
+        self.taxon_restriction = taxon_restriction
 
         if self.ontologies is None:
             self.ontologies = []

--- a/ontobio/config.yaml
+++ b/ontobio/config.yaml
@@ -28,4 +28,11 @@ ontologies:
   - id: magic1234
     handle: pato
     pre_load: true
-
+# taxon_restriction: 
+#   - NCBITaxon:10090
+#   - NCBITaxon:9606
+#   - NCBITaxon:10116
+#   - NCBITaxon:559292
+#   - NCBITaxon:6239
+#   - NCBITaxon:7955
+#   - NCBITaxon:7227


### PR DESCRIPTION
Restrict the results (e.g. annotations) based on provided taxons (if any)