### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     - pandoc
  
 # command to run tests
-script:
-  - pytest
+script: 
+  - PYTHONPATH=. make travis_test
 
 #after_success:
 #  coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     - pandoc
  
 # command to run tests
-script: 
-  - PYTHONPATH=. make travis_test
+script:
+  - pytest
 
 #after_success:
 #  coveralls

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -292,9 +292,9 @@ class AssocParser(object):
         for association in associations:
             pass
 
-    def validate_line(self, line: SplitLine):
+    def validate_line(self, line):
         if line == "":
-            self.report.warning(line.line, Report.WRONG_NUMBER_OF_COLUMNS, "",
+            self.report.warning(line, Report.WRONG_NUMBER_OF_COLUMNS, "",
                                 msg="GORULE:0000001: empty line", rule=1)
             return ParseResult(line, [], True)
 
@@ -336,7 +336,7 @@ class AssocParser(object):
                 raise ValueError("Line: {} has too few cols, expect class id in col {}".format(line, col))
             cid = vals[col]
             if cid not in class_map or len(class_map[cid]) == 0:
-                self.report.error(line.line, Report.UNMAPPED_ID, cid)
+                self.report.error(line, Report.UNMAPPED_ID, cid)
                 continue
             else:
                 for mcid in class_map[cid]:
@@ -454,7 +454,7 @@ class AssocParser(object):
 
         return id
 
-    def _normalize_gaf_date(self, date, line):
+    def _normalize_gaf_date(self, date, line: SplitLine):
         if date is None or date == "":
             self.report.warning(line.line, Report.INVALID_DATE, date, "GORULE:0000001: empty",
                 taxon=line.taxon, rule=1)

--- a/ontobio/neo/scigraph_ontology.py
+++ b/ontobio/neo/scigraph_ontology.py
@@ -157,7 +157,7 @@ class RemoteScigraphOntology(Ontology):
         if reflexive:
             ancestors.add(node)
         else:
-            if node in arr:
+            if node in ancestors:
                 ancestors.remove(node)
         return ancestors
 

--- a/tests/test_golr_associations.py
+++ b/tests/test_golr_associations.py
@@ -4,7 +4,7 @@ Tests for ontobio.golr.golr_associations
 from ontobio.golr.golr_associations import search_associations, search_associations_compact, select_distinct_subjects, get_objects_for_subject, get_subjects_for_object
 
 
-HUMAN_SHH = 'NCBIGene:6469'
+HUMAN_SHH = 'HGNC:10848'
 HOLOPROSENCEPHALY = 'HP:0001360'
 TWIST_ZFIN = 'ZFIN:ZDB-GENE-050417-357'
 DVPF = 'GO:0009953'

--- a/tests/test_wd_ontol.py
+++ b/tests/test_wd_ontol.py
@@ -39,7 +39,7 @@ def test_factory():
     labels = [ont.label(n) for n in nodes]
     print(labels)
     # Note: it's possible wd may change rendering this false
-    assert 'Fear of frogs' in labels
+    assert 'fear of frogs' in labels
     from ontobio.io.ontol_renderers import GraphRenderer
     w = GraphRenderer.create('tree')
     w.write(ont, query_ids=qids)


### PR DESCRIPTION
The following tests fail:
- [x] `tests/test_golr_associations.py` - fixed via b028f4b

- [x] `tests/test_map2slim.py` - fixed via 0f51001; needs review by @dougli1sqrd as the fix involves a change in assocparser.py

- [x] `tests/test_wd_ontol.py` - fixed via 1c2cdcb

- [x] `test/test_remote_scigraph.py` - fixed via 754b71f

- [x] `tests/test_remote_sparql.py`:
- fails on https://github.com/deepakunni3/ontobio/blob/d954ac22d74a9812191e8e5db1f6f2d9cecf0d58/tests/test_remote_sparql.py#L119 where it tries to assert the scope of the synonym to be `related` but the actual value of the scope is `OIO:hasRelatedSynonym`. 
 - `sparql/sparql_ontol_utils.py` has a `OIO_SYNS` dictionary that maps `oboInOwl:hasRelatedSynonym` to `related`, but after inspecting the code it looks like the incoming value is `OIO:hasRelatedSynonym` instead of `oboInOwl:hasRelatedSynonym`. i.e. it misses the mapping. 
- The observed difference is because after fetching the triples from the SPARQL endpoint, the URI `http://www.geneontology.org/formats/oboInOwl` is contracted to `OIO` instead of `oboInOwl`. This difference in behavior is due to prefixcommons-py (which is used for URI contraction) utilizing [monarch_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/monarch_context.jsonld) and [obo_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/obo_context.jsonld), by default.
- [monarch_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/monarch_context.jsonld) has `OIO` as the prefix for `http://www.geneontology.org/formats/oboInOwl`. Where as, [go_obo_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/go_obo_context.jsonld) has `oboInOwl` as the prefix for the same URI.
- @cmungall What would be the recommended approach here?
   - ~~Initialize prefixcommons-py to use [go_obo_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/go_obo_context.jsonld)~~
   - OR have both [monarch_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/monarch_context.jsonld) and [go_obo_context.jsonld](https://github.com/prefixcommons/biocontext/blob/master/registry/go_obo_context.jsonld) use the same prefix

