### PR TITLE
Fix bug when no results are returned

### DIFF
--- a/ontobio/sim/api/owlsim2.py
+++ b/ontobio/sim/api/owlsim2.py
@@ -365,13 +365,14 @@ class OwlSim2Api(SimApi, InformationContentStore, FilteredSearchable):
         sorted_results = sorted(
             results, reverse=True, key=lambda k: k[OwlSim2Api.method2key[method]]
         )
-        rank = 1
-        previous_score = sorted_results[0][OwlSim2Api.method2key[method]]
-        for result in sorted_results:
-            if previous_score > result[OwlSim2Api.method2key[method]]:
-                rank += 1
-            result['rank'] = rank
-            previous_score = result[OwlSim2Api.method2key[method]]
+        if len(sorted_results) > 0:
+            rank = 1
+            previous_score = sorted_results[0][OwlSim2Api.method2key[method]]
+            for result in sorted_results:
+                if previous_score > result[OwlSim2Api.method2key[method]]:
+                    rank += 1
+                result['rank'] = rank
+                previous_score = result[OwlSim2Api.method2key[method]]
 
         return sorted_results
 

--- a/tests/resources/owlsim2/mock-owlsim-noresults.json
+++ b/tests/resources/owlsim2/mock-owlsim-noresults.json
@@ -1,0 +1,5 @@
+{
+    "unresolved": [],
+    "query_IRIs": [],
+    "results": []
+}

--- a/tests/test_phenosim_engine.py
+++ b/tests/test_phenosim_engine.py
@@ -1,5 +1,6 @@
 from ontobio.sim.phenosim_engine import PhenoSimEngine
 from ontobio.sim.api.owlsim2 import OwlSim2Api
+from ontobio.vocabulary.similarity import SimAlgorithm
 
 from unittest.mock import MagicMock, patch
 import os
@@ -81,7 +82,6 @@ class TestPhenoSimEngine():
         )
         assert expected_sim_results == results
 
-
     def test_sim_compare(self):
         # Load fake output from owlsim2 and mock compare
         mock_search_fh = os.path.join(os.path.dirname(__file__),
@@ -104,3 +104,17 @@ class TestPhenoSimEngine():
                        )
         )
         assert expected_sim_results == results
+
+    def test_no_results(self):
+        """
+        Make sure ontobio handles no results correctly
+        """
+        # Load fake output from owlsim2 where no results are returned
+        mock_search_fh = os.path.join(os.path.dirname(__file__),
+                                      'resources/owlsim2/mock-owlsim-noresults.json')
+        mock_search = json.load(open(mock_search_fh))
+        self.owlsim2_api.search_by_attribute_set = MagicMock(return_value=mock_search)
+
+        classes = ['HP:0002367', 'HP:0031466', 'HP:0007123']
+        search_results = self.pheno_sim.search(classes, method=SimAlgorithm.SIM_GIC)
+        assert search_results.matches == []


### PR DESCRIPTION
Fixes bug that occurs when no results are returned by owlsim, for example:

https://api.monarchinitiative.org/api/sim/search?id=HP:0000006&id=HP:0000174&id=HP:0000194&id=HP:0000218&id=HP:0000238&id=HP:0000244&id=HP:0000272&id=HP:0000303&id=HP:0000316&id=HP:0000322&id=HP:0000324&id=HP:0000327&id=HP:0000348&id=HP:0000431&id=HP:0000452&id=HP:0000453&id=HP:0000470&id=HP:0000486&id=HP:0000494&id=HP:0000508&id=HP:0000586&id=HP:0000678&id=HP:0001156&id=HP:0001249&id=HP:0002308&id=HP:0002676&id=HP:0002780&id=HP:0003041&id=HP:0003070&id=HP:0003196&id=HP:0003272&id=HP:0003307&id=HP:0003795&id=HP:0004209&id=HP:0004322&id=HP:0004440&id=HP:0005048&id=HP:0005280&id=HP:0005347&id=HP:0006101&id=HP:0006110&id=HP:0009602&id=HP:0009773&id=HP:0010055&id=HP:0010669&id=HP:0011304&taxon=7227