### PR TITLE
Networkx 2.0 migration

### DIFF
--- a/ontobio/io/ontol_renderers.py
+++ b/ontobio/io/ontol_renderers.py
@@ -219,7 +219,7 @@ class SimpleListGraphRenderer(GraphRenderer):
         for n in ontol.nodes():
             s += self.render_noderef(ontol, n, **args) + "\n"
             #for n2 in ontol.parents(n):
-            #    for _,ea in g[n2][n].items():
+            #    for _,ea in g.get_edge_data(n2,n).items():
             #        s += '  {} {}'.format(str(ea['pred']), self.render_noderef(ontol, n2, **args))
             #        s += "\n"
         return s
@@ -255,7 +255,7 @@ class AsciiTreeGraphRenderer(GraphRenderer):
         s += "\n"
         for c in ontol.children(n):
             preds = []
-            for _,ea in g[n][c].items():
+            for _,ea in g.get_edge_data(n,c).items():
                 preds.append(ea['pred'])
             s+= self._show_tree_node(",".join(preds), c, ontol, depth+1, path+[n], **args)
         return s
@@ -270,7 +270,7 @@ class OboFormatGraphRenderer(GraphRenderer):
         super().__init__(**args)
         
     def render(self, ontol, **args):
-        ts = ontol.nodes()
+        ts = [n for n in ontol.nodes()]
         ts.sort()
         s = "ontology: auto\n\n"
         for n in ts:
@@ -349,7 +349,7 @@ class OboFormatGraphRenderer(GraphRenderer):
         s += self.tag('id ! TODO', nid)
         s += self.tag('name', n['label'])
         for p in g.predecessors(nid):
-            for _,ea in g[p][nid].items():
+            for _,ea in g.get_edge_data(p,nid).items():
                 pred = ea['pred']
                 if p in g and 'label' in g.node[p]:
                     p = '{} ! {}'.format(p, g.node[p]['label'])
@@ -386,7 +386,7 @@ class OboJsonGraphRenderer(GraphRenderer):
             node_objs.append(self.node_to_json(n, ontol, **args))
         obj['nodes'] = node_objs
         edge_objs = []
-        for e in g.edges_iter(data=True):
+        for e in g.edges(data=True):
             edge_objs.append(self.edge_to_json(e, ontol, **args))
         obj['edges'] = edge_objs
 

--- a/ontobio/lexmap.py
+++ b/ontobio/lexmap.py
@@ -325,10 +325,10 @@ class LexicalMapEngine():
         # graph of best matches
         xg = nx.Graph()
         for i in g.nodes():
-            for j in nx.neighbors(g,i):
+            for j in g.neighbors(i):
                 best = 0
                 bestm = None
-                for m in g[i][j].values():
+                for m in g.get_edge_data(i,j).values():
                     (s1,s2) = m['syns']
                     score = self._combine_syns(s1,s2)
                     if score > best:
@@ -375,7 +375,7 @@ class LexicalMapEngine():
         the semantic similarity of matches.
         """
         logging.info("scoring xrefs by semantic similarity for {} nodes in {}".format(len(xg.nodes()), ont))
-        for (i,j,d) in xg.edges_iter(data=True):
+        for (i,j,d) in xg.edges(data=True):
             pfx1 = self._id_to_ontology(i)
             pfx2 = self._id_to_ontology(j)
             ancs1 = self._blanket(i)
@@ -434,7 +434,7 @@ class LexicalMapEngine():
         Compares a base xref graph with another one
         """
         ont = self.merged_ontology
-        for (i,j,d) in xg1.edges_iter(data=True):
+        for (i,j,d) in xg1.edges(data=True):
             ont_left = self._id_to_ontology(i)
             ont_right = self._id_to_ontology(j)
             unique_lr = True
@@ -490,7 +490,7 @@ class LexicalMapEngine():
                     edge_ij = xg[i][j]
                     dirn_ij = self._dirn(edge_ij, i, j)
                     edge_ij['cpr_'+dirn_ij] = score / sum([s for s,_ in score_node_pairs])
-        for (i,j,edge) in xg.edges_iter(data=True):
+        for (i,j,edge) in xg.edges(data=True):
             # reciprocal score is set if (A) i is best for j, and (B) j is best for i
             rs = 0
             if 'best_fwd' in edge and 'best_rev' in edge:
@@ -799,7 +799,7 @@ class LexicalMapEngine():
         cliques = self.cliques(xg)
         ont = self.merged_ontology
         items = []
-        for x,y,d in xg.edges_iter(data=True):
+        for (x,y,d) in xg.edges(data=True):
             # xg is a non-directional Graph object.
             # to get a deterministic ordering we use the idpair key
             (x,y) = d['idpair']
@@ -868,9 +868,9 @@ class LexicalMapEngine():
         list of sets
         """
         g = nx.DiGraph()
-        for x,y in self.merged_ontology.get_graph().edges():
+        for (x,y) in self.merged_ontology.get_graph().edges():
             g.add_edge(x,y)
-        for x,y in xg.edges():
+        for (x,y) in xg.edges():
             g.add_edge(x,y)
             g.add_edge(y,x)
         return list(strongly_connected_components(g))

--- a/ontobio/neo/scigraph_ontology.py
+++ b/ontobio/neo/scigraph_ontology.py
@@ -113,7 +113,7 @@ class RemoteScigraphOntology(Ontology):
             r_edges += g['edges']
         digraph = nx.MultiDiGraph()
         for n in r_nodes:
-            digraph.add_node(n['id'], attr_dict=self._repair(n))
+            digraph.add_node(n['id'], **self._repair(n))
         for e in r_edges:
             digraph.add_edge(e['obj'],e['sub'], pred=e['pred'])
         return digraph

--- a/ontobio/obograph_util.py
+++ b/ontobio/obograph_util.py
@@ -39,7 +39,7 @@ class OboJsonMapper(object):
             if node_type is not None and ('type' not in n or n['type'] != node_type):
                 continue
             id = self.contract_uri(n['id'])
-            digraph.add_node(id, attr_dict=n)
+            digraph.add_node(id, **n)
             if 'lbl' in n:
                 digraph.node[id]['label'] = n['lbl']
             if parse_meta and 'meta' in n:

--- a/ontobio/ontol.py
+++ b/ontobio/ontol.py
@@ -120,15 +120,15 @@ class Ontology():
 
         # TODO: copy full metadata
         logger.info("copying nodes")
-        for n,d in srcg.nodes_iter(data=True):
-            g.add_node(n, attr_dict=d)
+        for (n,d) in srcg.nodes(data=True):
+            g.add_node(n, **d)
 
         logger.info("copying edges")
         num_edges = 0
-        for x,y,d in srcg.edges_iter(data=True):
+        for (x,y,d) in srcg.edges(data=True):
             if d['pred'] in relations:
                 num_edges += 1
-                g.add_edge(x,y,attr_dict=d)
+                g.add_edge(x,y,**d)
         logger.info("Filtered edges: {}".format(num_edges))
         return g
 
@@ -144,12 +144,12 @@ class Ontology():
             g = self.get_graph()
             srcg = ont.get_graph()
             for n in srcg.nodes():
-                g.add_node(n, attr_dict=srcg.node[n])
+                g.add_node(n, **srcg.node[n])
             for (o,s,m) in srcg.edges(data=True):
-                g.add_edge(o,s,attr_dict=m)
+                g.add_edge(o,s,**m)
             if ont.xref_graph is not None:
                 for (o,s,m) in ont.xref_graph.edges(data=True):
-                    self.xref_graph.add_edge(o,s,attr_dict=m)
+                    self.xref_graph.add_edge(o,s,**m)
 
     def subgraph(self, nodes=None):
         """
@@ -364,7 +364,7 @@ class Ontology():
         """
         g = self.get_graph()
         types = set()
-        for x,y,d in g.edges_iter(data=True):
+        for (x,y,d) in g.edges(data=True):
             types.add(d['pred'])
         return list(types)
 
@@ -412,7 +412,7 @@ class Ontology():
         """
         g = self.get_graph()
         if node in g:
-            parents = g.predecessors(node)
+            parents = [x for x in g.predecessors(node)]
             if relations is None:
                 return parents
             else:
@@ -441,7 +441,7 @@ class Ontology():
         """
         g = self.get_graph()
         if node in g:
-            children = g.successors(node)
+            children = [ x for x in g.successors(node)]
             if relations is None:
                 return children
             else:
@@ -533,7 +533,7 @@ class Ontology():
             bidirectional networkx graph of all equivalency relations
         """
         eg = nx.Graph()
-        for u,v,d in self.get_graph().edges_iter(data=True):
+        for (u,v,d) in self.get_graph().edges(data=True):
             if d['pred'] == 'equivalentTo':
                 eg.add_edge(u,v)
         return eg
@@ -583,7 +583,7 @@ class Ontology():
         """
         g = self.get_filtered_graph(relations=relations, prefix=prefix)
         # note: we also eliminate any singletons, which includes obsolete classes
-        roots = [n for n in g.nodes() if len(g.predecessors(n)) == 0 and len(g.successors(n)) > 0]
+        roots = [n for n in g.nodes() if len([x for x in g.predecessors(n)]) == 0 and len([x for x in g.successors(n)]) > 0]
         return roots
 
     def get_level(self, level, relations=None, **args):
@@ -624,7 +624,7 @@ class Ontology():
             g = self.get_filtered_graph(relations)
         l = []
         for n in g:
-            l.append([n] + g.predecessors(n))
+            l.append([n] + [p for p in g.predecessors(n)])
         return l
 
     def text_definition(self, nid):
@@ -918,7 +918,7 @@ class Ontology():
             if nid not in xg:
                 return []
             if bidirectional:
-                return xg.neighbors(nid)
+                return [x for x in xg.neighbors(nid)]
             else:
                 return [x for x in xg.neighbors(nid) if xg[nid][x][0]['source'] == nid]
 

--- a/ontobio/ontol.py
+++ b/ontobio/ontol.py
@@ -412,7 +412,7 @@ class Ontology():
         """
         g = self.get_graph()
         if node in g:
-            parents = [x for x in g.predecessors(node)]
+            parents = list(g.predecessors(node))
             if relations is None:
                 return parents
             else:
@@ -441,7 +441,7 @@ class Ontology():
         """
         g = self.get_graph()
         if node in g:
-            children = [ x for x in g.successors(node)]
+            children = list(g.successors(node))
             if relations is None:
                 return children
             else:
@@ -583,7 +583,7 @@ class Ontology():
         """
         g = self.get_filtered_graph(relations=relations, prefix=prefix)
         # note: we also eliminate any singletons, which includes obsolete classes
-        roots = [n for n in g.nodes() if len([x for x in g.predecessors(n)]) == 0 and len([x for x in g.successors(n)]) > 0]
+        roots = [n for n in g.nodes() if len(list(g.predecessors(n))) == 0 and len(list(g.successors(n))) > 0]
         return roots
 
     def get_level(self, level, relations=None, **args):
@@ -624,7 +624,7 @@ class Ontology():
             g = self.get_filtered_graph(relations)
         l = []
         for n in g:
-            l.append([n] + [p for p in g.predecessors(n)])
+            l.append([n] + list(g.predecessors(n)))
         return l
 
     def text_definition(self, nid):
@@ -918,7 +918,7 @@ class Ontology():
             if nid not in xg:
                 return []
             if bidirectional:
-                return [x for x in xg.neighbors(nid)]
+                return list(xg.neighbors(nid))
             else:
                 return [x for x in xg.neighbors(nid) if xg[nid][x][0]['source'] == nid]
 

--- a/ontobio/slimmer.py
+++ b/ontobio/slimmer.py
@@ -77,12 +77,12 @@ def get_minimal_subgraph(g, nodes):
 def remove_nodes(g, rmnodes):
     logging.info("Removing {} from {}".format(rmnodes,g))
     newg = nx.MultiDiGraph()
-    for n,nd in g.nodes(data=True):
+    for (n,nd) in g.nodes(data=True):
         if n not in rmnodes:
-            newg.add_node(n, attr_dict=nd)
+            newg.add_node(n, **nd)
             parents = _traverse(g, set([n]), set(rmnodes), set())
             for p in parents:
-                newg.add_edge(p,n,attr_dict={'pred':'subClassOf'})
+                newg.add_edge(p,n,**{'pred':'subClassOf'})
     return newg     
 
 def _traverse(g, nset, rmnodes, acc):

--- a/ontobio/sparql/rdf2nx.py
+++ b/ontobio/sparql/rdf2nx.py
@@ -62,9 +62,8 @@ class RdfMapper():
 
         # propagate label from type
         for s in typemap.keys():
-            g[s]['types'] = typemap[s]
+            g.nodes[s]['types'] = typemap[s]
             if self.tbox_ontology is not None:
-                if 'label' not in g[s]:
-                    g[s]['label'] = ";".join([self.tbox_ontology.label(x) for x in typemap[s] if self.tbox_ontology.label(x) is not None])
-            
+                if 'label' not in g.nodes[s]:
+                    g.nodes[s]['label'] = ";".join([self.tbox_ontology.label(x) for x in typemap[s] if self.tbox_ontology.label(x) is not None])
         

--- a/ontobio/sparql/sparql_ontol_utils.py
+++ b/ontobio/sparql/sparql_ontol_utils.py
@@ -74,7 +74,7 @@ def get_digraph(ont, relations=None, writecache=False):
             digraph.add_edge(o,s,pred=p)
     logging.info("Getting labels (may be cached)")
     for (n,label) in fetchall_labels(ont):
-        digraph.add_node(n, attr_dict={'label':label})
+        digraph.add_node(n, **{'label':label})
     return digraph
 
 def get_xref_graph(ont):

--- a/ontobio/xref_util.py
+++ b/ontobio/xref_util.py
@@ -2,7 +2,7 @@
 def materialize_xrefs_as_edges(ont, xref_graph=None):
     if xref_graph is None:
         xref_graph = ont.xref_graph
-    for x,y in xref_graph.edges_iter():
+    for (x,y) in xref_graph.edges(data=True):
         nodes = ont.nodes()
         if x in nodes and y in nodes:
             ont.add_parent(x,y,'xref')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ requests>=0.0
 pip>=9.0.1
 wheel>0.25.0
 pysolr==3.6.0
-networkx==1.11
+networkx==2.2
 matplotlib==2.0.0
 SPARQLWrapper==1.8.0
 pandas>=0.0
-scipy==0.19.1
+scipy==1.2.0
 twine
 jsonpickle>=0.0
 jsonpath_rw>=0.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
 
     # Dependencies
     install_requires=[
-        'networkx==1.11',
+        'networkx==2.2',
         'jsobject',
         'pyyaml==3.13',
         'pysolr',

--- a/tests/test_lexmap.py
+++ b/tests/test_lexmap.py
@@ -35,7 +35,7 @@ def test_align():
     print(ont1.all_synonyms())
     print(ont2.all_synonyms())
     g = lexmap.get_xref_graph()
-    for x,y,d in g.edges_iter(data=True):
+    for (x,y,d) in g.edges(data=True):
         print("{}<->{} :: {}".format(x,y,d))
     for x in g.nodes():
         print("{} --> {}".format(x,lexmap.grouped_mappings(x)))

--- a/tests/test_lexmap_local.py
+++ b/tests/test_lexmap_local.py
@@ -27,7 +27,7 @@ def test_lexmap_basic():
     print(lexmap.lmap)
     print(ont.all_synonyms())
     g = lexmap.get_xref_graph()
-    for x,y,d in g.edges_iter(data=True):
+    for (x,y,d) in g.edges(data=True):
         print("{}<->{} :: {}".format(x,y,d))
     for x in g.nodes():
         print("{} --> {}".format(x,lexmap.grouped_mappings(x)))
@@ -35,7 +35,7 @@ def test_lexmap_basic():
     assert g.has_edge('Z:2','Y:2')  # case insensitivity
     assert g.has_edge('A:1','B:1')  # synonyms
     assert g.has_edge('B:1','A:1')  # bidirectional
-    for x,y,d in g.edges_iter(data=True):
+    for (x,y,d) in g.edges(data=True):
         print("{}<->{} :: {}".format(x,y,d))
         cpr = d[lexmap.CONDITIONAL_PR]
         assert cpr > 0 and cpr <= 1.0
@@ -115,7 +115,7 @@ def test_lexmap_multi():
     g = lexmap.get_xref_graph()
     for x in g.nodes():
         print("{} --> {}".format(x,lexmap.grouped_mappings(x)))
-    for x,y,d in g.edges_iter(data=True):
+    for (x,y,d) in g.edges(data=True):
         cl = nx.ancestors(g,x)
         print("{} '{}' <-> {} '{}' :: {} CLOSURE={}".format(x,lexmap.label(x),y,lexmap.label(y),d,len(cl)))
         cpr = d[lexmap.CONDITIONAL_PR]
@@ -216,7 +216,7 @@ def test_awe_1_to_many_hier():
     Text axiom weight estimation
     """
     ont = Ontology()
-    assert ont.nodes() == []
+    assert isinstance(ont.nodes(), nx.classes.reportviews.NodeView)
     lexmap = LexicalMapEngine()
     
     ont.add_node('X:1', 'foo 1')
@@ -240,7 +240,7 @@ def test_awe_1_to_1():
     Text axiom weight estimation
     """
     ont = Ontology()
-    assert ont.nodes() == []
+    assert isinstance(ont.nodes(), nx.classes.reportviews.NodeView)
     lexmap = LexicalMapEngine(config={'cardinality_weights': [
         {'prefix1':'X',
          'prefix2':'Y',
@@ -268,7 +268,7 @@ def test_awe_match_pairs():
     Text axiom weight estimation
     """
     ont = Ontology()
-    assert ont.nodes() == []
+    assert isinstance(ont.nodes(), nx.classes.reportviews.NodeView)
     lexmap = LexicalMapEngine(config={'match_weights': [
         {'prefix1':'X',
          'prefix2':'Y',
@@ -295,7 +295,7 @@ def test_awe_scope_map():
     Text axiom weight estimation, syn scopes
     """
     ont = Ontology()
-    assert ont.nodes() == []
+    assert isinstance(ont.nodes(), nx.classes.reportviews.NodeView)
     lexmap = LexicalMapEngine()    
     ont.add_node('X:1', 'x1')
     ont.add_node('Y:1', 'y1')
@@ -324,7 +324,7 @@ def test_awe_xref_weights():
     Text axiom weight estimation, when provided with defaults
     """
     ont = Ontology()
-    assert ont.nodes() == []
+    assert isinstance(ont.nodes(), nx.classes.reportviews.NodeView)
     lexmap = LexicalMapEngine(config={'xref_weights':[
         {'left':'X:1',
          'right':'Y:1',

--- a/tests/test_local_ttl.py
+++ b/tests/test_local_ttl.py
@@ -26,7 +26,7 @@ def test_local_json_parse():
     w = GraphRenderer.create(None)
     w.write_subgraph(ont, nodes)
     i = 'http://model.geneontology.org/0000000300000001/0000000300000007'
-    ni = g[i]
+    ni = g.nodes[i]
     print(str(ni))
     ['GO:0060070'] == ni['types']
     nbrs = ont.neighbors(i)

--- a/tests/test_sparql_connection.py
+++ b/tests/test_sparql_connection.py
@@ -19,9 +19,9 @@ def test_remote_sparql():
     nodes = g.nodes()
     print(len(nodes))
     assert len(nodes) > 100
-    nbrs = g.successors(PLOIDY)
+    nbrs = [n for n in g.successors(PLOIDY)]
     print("SUCC:"+str(nbrs))
-    parents = g.predecessors(PLOIDY)
+    parents = [p for p in g.predecessors(PLOIDY)]
     print("PRED:"+str(parents))
     assert parents == ['PATO:0001396']
     ancs = ancestors(g, PLOIDY)

--- a/tests/test_sparql_connection.py
+++ b/tests/test_sparql_connection.py
@@ -19,9 +19,9 @@ def test_remote_sparql():
     nodes = g.nodes()
     print(len(nodes))
     assert len(nodes) > 100
-    nbrs = [n for n in g.successors(PLOIDY)]
+    nbrs = list(g.successors(PLOIDY))
     print("SUCC:"+str(nbrs))
-    parents = [p for p in g.predecessors(PLOIDY)]
+    parents = list(g.predecessors(PLOIDY))
     print("PRED:"+str(parents))
     assert parents == ['PATO:0001396']
     ancs = ancestors(g, PLOIDY)


### PR DESCRIPTION
There are a few changes between networkx 1.x and networkx 2.x

This PR upgrades networkx dependency from 1.11 to 2.2.
It also makes the necessary changes across the Ontobio codebase.

**The official migration documentation:** https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html

**Lessons learned (an unofficial migration documentation):**

* `graph.nodes_iter()` is now replaced with `graph.nodes()`
* `graph.edges_iter()` is now replaced with `graph.edges()`
* `graph.nodes()` will return an NodeView. Convert this to a list via `list(graph.nodes())`
* `graph.edges()` will return an EdgeDataView. Convert this to a list via `list(graph.edges())`
* `graph.edges()` will return a tuple of edges, `(u,v)`
* `graph.edges(data=True)` will return a 3-tuple, `(u,v,d)`
* `graph.add_node()` does not have `attr_dict` argument anymore. Instead, supply all properties of a node as keyword arguments. Similarly for `graph.add_edge()`
* To add a new property to a node,
```py
graph.nodes[n]['property_name'] = value
```

* To add a new property to an edge,
```py
# for a DiGraph
graph[u][v]['property_name'] = value
# for a MultiDiGraph
graph[u][v][0]['property_name'] = value
```

* Accessing edge properties,
```py
graph.get_edge_data(u, v)
```

* `networkx.neighbors()` method has been moved to `graph.neighbors()`



