### PR TITLE
Add max ic to sim result object

### DIFF
--- a/ontobio/model/similarity.py
+++ b/ontobio/model/similarity.py
@@ -42,6 +42,14 @@ class TypedNode(Node):
         self.type = type
         self.taxon = taxon
 
+class SimMetadata():
+    """
+    Metadata returned with sim result
+    """
+
+    def __init__(self, max_max_ic: float):
+        self.max_max_ic = max_max_ic
+
 
 class PairwiseMatch:
     """
@@ -110,9 +118,11 @@ class SimResult:
     """
     def __init__(self,
                  query: SimQuery,
-                 matches: List[SimMatch]):
+                 matches: List[SimMatch],
+                 metadata: SimMetadata):
         self.query = query
         self.matches = matches
+        self.metadata = metadata
 
 
 class IcStatistic:

--- a/ontobio/sim/api/owlsim2.py
+++ b/ontobio/sim/api/owlsim2.py
@@ -75,7 +75,7 @@ def compare_attribute_sets(
 
 @cachier(SHELF_LIFE)
 def get_attribute_information_profile(
-        url,
+        url: str,
         profile: Optional[Tuple[str]]=None,
         categories: Optional[Tuple[str]]=None) -> Dict:
     """

--- a/ontobio/sim/phenosim_engine.py
+++ b/ontobio/sim/phenosim_engine.py
@@ -1,6 +1,6 @@
 from ontobio.sim.api.interfaces import SimApi
 from typing import Iterable, Dict, Union, Optional, List
-from ontobio.model.similarity import SimResult, SimQuery, Node
+from ontobio.model.similarity import SimResult, TypedNode
 from ontobio.vocabulary.similarity import SimAlgorithm
 from ontobio.sim.api.interfaces import FilteredSearchable
 from ontobio.golr.golr_associations import get_objects_for_subject
@@ -102,6 +102,13 @@ class PhenoSimEngine():
 
         if len(reference_ids) == 1:
             comparisons.query.reference = typed_node_from_id(reference_ids[0])
+        else:
+            reference_id = " + ".join(reference_ids)
+            comparisons.query.reference = TypedNode(
+                id=reference_id,
+                label=reference_id,
+                type='unknown'
+            )
 
         return comparisons
 

--- a/tests/resources/owlsim2/mock-sim-compare.json
+++ b/tests/resources/owlsim2/mock-sim-compare.json
@@ -88,5 +88,8 @@
             "id":"NCBITaxon:9606"
          }
       }
+   },
+   "metadata": {
+      "max_max_ic": 16.16108
    }
 }

--- a/tests/resources/owlsim2/mock-sim-search.json
+++ b/tests/resources/owlsim2/mock-sim-search.json
@@ -150,5 +150,8 @@
       "reference":null,
       "target_ids":[[]],
       "unresolved_ids":[]
+   },
+   "metadata": {
+      "max_max_ic": 16.16108
    }
 }

--- a/tests/test_phenosim_engine.py
+++ b/tests/test_phenosim_engine.py
@@ -1,9 +1,7 @@
 from ontobio.sim.phenosim_engine import PhenoSimEngine
-from ontobio.sim.api.owlsim2 import OwlSim2Api
+from ontobio.sim.api.owlsim2 import OwlSim2Api, search_by_attribute_set
 from ontobio.vocabulary.similarity import SimAlgorithm
 from ontobio.model.similarity import IcStatistic
-
-
 
 from unittest.mock import MagicMock, patch
 import os
@@ -33,7 +31,6 @@ def mock_get_scigraph_nodes(id_list):
     for node in scigraph_res['nodes']:
         if node['id'] in ids:
             yield node
-
 
 class TestPhenoSimEngine():
     """
@@ -77,7 +74,8 @@ class TestPhenoSimEngine():
         mock_search_fh = os.path.join(os.path.dirname(__file__),
                                       'resources/owlsim2/mock-owlsim-search.json')
         mock_search = json.load(open(mock_search_fh))
-        self.owlsim2_api.search_by_attribute_set = MagicMock(return_value=mock_search)
+        patch('ontobio.sim.api.owlsim2.search_by_attribute_set',
+              return_value=mock_search).start()
 
         expected_fh = os.path.join(os.path.dirname(__file__),
                                    'resources/owlsim2/mock-sim-search.json')
@@ -99,7 +97,8 @@ class TestPhenoSimEngine():
         mock_search_fh = os.path.join(os.path.dirname(__file__),
                                       'resources/owlsim2/mock-owlsim-compare.json')
         mock_compare = json.load(open(mock_search_fh))
-        self.owlsim2_api.compare_attribute_sets = MagicMock(return_value=mock_compare)
+        patch('ontobio.sim.api.owlsim2.compare_attribute_sets',
+              return_value=mock_compare).start()
 
         expected_fh = os.path.join(os.path.dirname(__file__),
                                    'resources/owlsim2/mock-sim-compare.json')
@@ -125,7 +124,9 @@ class TestPhenoSimEngine():
         mock_search_fh = os.path.join(os.path.dirname(__file__),
                                       'resources/owlsim2/mock-owlsim-noresults.json')
         mock_search = json.load(open(mock_search_fh))
-        self.owlsim2_api.search_by_attribute_set = MagicMock(return_value=mock_search)
+
+        patch('ontobio.sim.api.owlsim2.search_by_attribute_set',
+              return_value=mock_search).start()
 
         classes = ['HP:0002367', 'HP:0031466', 'HP:0007123']
         search_results = self.pheno_sim.search(classes, method=SimAlgorithm.SIM_GIC)

--- a/tests/test_phenosim_engine.py
+++ b/tests/test_phenosim_engine.py
@@ -1,6 +1,9 @@
 from ontobio.sim.phenosim_engine import PhenoSimEngine
 from ontobio.sim.api.owlsim2 import OwlSim2Api
 from ontobio.vocabulary.similarity import SimAlgorithm
+from ontobio.model.similarity import IcStatistic
+
+
 
 from unittest.mock import MagicMock, patch
 import os
@@ -48,6 +51,15 @@ class TestPhenoSimEngine():
                                    side_effect=mock_get_scigraph_nodes)
 
         self.owlsim2_api = OwlSim2Api()
+        self.owlsim2_api.statistics = IcStatistic(
+            mean_mean_ic=6.82480,
+            mean_sum_ic=120.89767,
+            mean_cls=15.47425,
+            max_max_ic=16.16108,
+            max_sum_ic=6746.96160,
+            individual_count=65309,
+            mean_max_ic=9.51535
+        )
         self.pheno_sim = PhenoSimEngine(self.owlsim2_api)
 
         self.resolve_mock.start()


### PR DESCRIPTION
Global max IC is needed for phenogrid, adding metadata field with max_max_ic and updated the tests as needed.  Also added cachier to owlsim calls.