### PR TITLE
Add support for stats field

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -818,7 +818,7 @@ class GolrAssociationQuery(GolrAbstractQuery):
                  facet_mincount=1,
                  facet_pivot_fields=None,
                  stats=False,
-                 stats_fields=None,
+                 stats_field=None,
                  facet_on = 'on',
                  pivot_subject_object=False,
                  unselect_evidence=False,
@@ -870,7 +870,7 @@ class GolrAssociationQuery(GolrAbstractQuery):
         self.facet_mincount=facet_mincount
         self.facet_pivot_fields=facet_pivot_fields
         self.stats=stats
-        self.stats_fields=stats_fields
+        self.stats_field=stats_field
         self.facet_on=facet_on
         self.pivot_subject_object=pivot_subject_object
         self.unselect_evidence=unselect_evidence
@@ -1240,9 +1240,9 @@ class GolrAssociationQuery(GolrAbstractQuery):
             params['facet.pivot'] = ",".join(facet_pivot_fields)
             params['facet.pivot.mincount'] = 1
 
-        if self.stats_fields:
+        if self.stats_field:
             self.stats = True
-            params['stats.field'] = self.stats_fields
+            params['stats.field'] = self.stats_field
         params['stats'] = json.dumps(self.stats)
 
         return params

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -817,6 +817,8 @@ class GolrAssociationQuery(GolrAbstractQuery):
                  facet_limit=25,
                  facet_mincount=1,
                  facet_pivot_fields=None,
+                 stats=False,
+                 stats_fields=None,
                  facet_on = 'on',
                  pivot_subject_object=False,
                  unselect_evidence=False,
@@ -867,6 +869,8 @@ class GolrAssociationQuery(GolrAbstractQuery):
         self.facet_limit=facet_limit
         self.facet_mincount=facet_mincount
         self.facet_pivot_fields=facet_pivot_fields
+        self.stats=stats
+        self.stats_fields=stats_fields
         self.facet_on=facet_on
         self.pivot_subject_object=pivot_subject_object
         self.unselect_evidence=unselect_evidence
@@ -1235,6 +1239,11 @@ class GolrAssociationQuery(GolrAbstractQuery):
         if len(facet_pivot_fields) > 0:
             params['facet.pivot'] = ",".join(facet_pivot_fields)
             params['facet.pivot.mincount'] = 1
+
+        if self.stats_fields:
+            self.stats = True
+            params['stats.field'] = self.stats_fields
+        params['stats'] = json.dumps(self.stats)
 
         return params
 


### PR DESCRIPTION
Currently the `stats` and `stats.field` parameters are ignored when passed to `GolrAssociationQuery`.

This PR adds support for these parameters.

Required for https://github.com/biolink/biolink-api/pull/231