### PR TITLE
Upgrade pyyaml req due to vulnerability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     install_requires=[
         'networkx==2.2',
         'jsobject',
-        'pyyaml==3.13',
+        'pyyaml>=4.2b1',
         'pysolr',
         'requests',
         'sparqlwrapper',


### PR DESCRIPTION
This was causing the annoying security vulnerability warning to appear in some of my repos due to a pyyaml version < 4.2b1 (3.13) being installed through ontobio.