### PR TITLE
basic skeleton of an internal Association object

### DIFF
--- a/ontobio/config.yaml
+++ b/ontobio/config.yaml
@@ -1,15 +1,15 @@
 solr_assocs:
   url: "https://solr.monarchinitiative.org/solr/golr"
-  timeout: 5
+  timeout: 10
 amigo_solr_assocs:
   url: "http://golr-aux.geneontology.io/solr"
   timeout: 4
 solr_search:
   url: "https://solr.monarchinitiative.org/solr/search"
-  timeout: 2
+  timeout: 5
 lay_person_search:
   url: "https://solr.monarchinitiative.org/solr/hpo-pl"
-  timeout: 2
+  timeout: 5
 amigo_solr_search:
   url: "http://golr-aux.geneontology.io/solr"
   timeout: 2

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -51,8 +51,8 @@ class ExtensionExpression:
     conjunctions: List[ExtensionConjunctions]
 
 @dataclass(repr=True, unsafe_hash=True)
-class Association:
-    source_line: str
+class GoAssociation:
+    source_line: Optional[str]
     subject: Subject
     relation: Curie # This is the relation Curie
     object: Term
@@ -66,6 +66,3 @@ class Association:
     provided_by: Provider
     date: Date
     properties: Dict[Curie, List[str]]
-
-    def __str__(self):
-        return self.source_line

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -42,15 +42,14 @@ class ExtensionExpression(NamedTuple):
     """
     conjunctions: List[ExtensionConjunctions]
 
-@dataclass(repr=False, unsafe_hash=True)
-class Association:
+class Association(NamedTuple):
     source_line: str
     subject: Subject
     relation: Curie # This is the relation Curie
     object: Term
     negated: bool
     qualifiers: List[Curie]
-    aspect: Aspect
+    aspect: Optional[Aspect]
     interacting_taxon: Optional[Curie]
     evidence: Evidence
     subject_extensions: List[ExtensionUnit]
@@ -59,5 +58,5 @@ class Association:
     date: Date
     properties: Dict[Curie, List[str]]
 
-    def __repr__(self):
+    def __str__(self):
         return self.source_line

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -5,35 +5,44 @@ import enum
 import datetime
 
 from typing import List, Optional, NamedTuple, Dict
+from dataclasses import dataclass
 
-
-# why named tuple and not a class?
-Subject = collections.namedtuple("Subject", ["id", "label", "type", "fullname", "synonyms", "taxon"])
-Term = collections.namedtuple("Term", ["id", "taxon"])
-
-# this should be kept general for the general association class
-Aspect = enum.Enum("Aspect", {
-    "F": "F",
-    "P": "P",
-    "C": "C"
-    })
+Aspect = typing.NewType("Aspect", str)
 Curie = typing.NewType("Curie", str)
 Provider = typing.NewType("Provider", str)
-Date = typing.NewType("Date", str) ## actual datetime object is false precision
+Date = typing.NewType("Date", str)
 
-class Evidence(NamedTuple):
+@dataclass
+class Subject:
+    id: Curie
+    label: str
+    type: str
+    fullname: str
+    synonyms: List[str]
+    taxon: Curie
+
+@dataclass
+class Term:
+    id: Curie
+    taxon: Curie
+
+@dataclass
+class Evidence:
     type: Curie # Curie of the ECO class
     has_supporting_reference: List[Curie]
     with_support_from: List[Curie]
 
-class ExtensionUnit(NamedTuple):
+@dataclass
+class ExtensionUnit:
     relation: Curie
     term: Curie
 
-class ExtensionConjunctions(NamedTuple):
+@dataclass
+class ExtensionConjunctions:
     extensions: List[ExtensionUnit]
 
-class ExtensionExpression(NamedTuple):
+@dataclass
+class ExtensionExpression:
     """
     ExtensionExpression ::= ConjunctionExpression { "|" ConjunctionExpression }
     ConjunctionExpression ::= ExtensionUnit { "," ExtensionUnit }
@@ -41,7 +50,8 @@ class ExtensionExpression(NamedTuple):
     """
     conjunctions: List[ExtensionConjunctions]
 
-class Association(NamedTuple):
+@dataclass(repr=True, unsafe_hash=True)
+class Association:
     source_line: str
     subject: Subject
     relation: Curie # This is the relation Curie

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -4,9 +4,9 @@ import collections
 import enum
 import datetime
 
-from typing import List, Optional, NamedTuple
+from typing import List, Optional, NamedTuple, Dict
+from dataclasses import dataclass
 
-# Note: This requires python 3.7
 
 # why named tuple and not a class?
 Subject = collections.namedtuple("Subject", ["id", "label", "type", "fullname", "synonyms", "taxon"])

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -1,0 +1,58 @@
+import json
+import typing
+import collections
+import enum
+import datetime
+
+from typing import List, Optional, NamedTuple
+
+# Note: This requires python 3.7
+
+Subject = collections.namedtuple("Subject", ["id", "label", "type", "fullname", "synonyms", "taxon"])
+Term = collections.namedtuple("Term", ["id", "taxon"])
+Aspect = enum.Enum("Aspect", {
+    "F": "F",
+    "P": "P",
+    "C": "C"
+    })
+Curie = typing.NewType("Curie", str)
+
+class Evidence(NamedTuple):
+    type: Curie # Curie of the ECO class
+    has_supporting_reference: List[Curie]
+    with_support_from: List[Curie]
+
+class ExtensionUnit(NamedTuple):
+    relation: Curie
+    term: Curie
+
+class ExtensionConjunctions(NamedTuple):
+    extensions: List[ExtensionUnit]
+
+class ExtensionExpression(NamedTuple):
+    """
+    ExtensionExpression ::= ConjunctionExpression { "|" ConjunctionExpression }
+    ConjunctionExpression ::= ExtensionUnit { "," ExtensionUnit }
+    ExtensionUnit ::= Relation "(" Term ")"
+    """
+    conjunctions: List[ExtensionConjunctions]
+
+@dataclass(repr=False, unsafe_hash=True)
+class Association:
+    source_line: str
+    subject: Subject
+    relation: Curie # This is the relation Curie
+    object: Term
+    negated: bool
+    qualifiers: List[str]
+    aspect: Aspect
+    interacting_taxon: Optional[Curie]
+    evidence: Evidence
+    subject_extensions: List[ExtensionUnit]
+    object_extensions: ExtensionExpression
+    provided_by: str
+    date: datetime.datetime
+    properties: Dict[Curie, List[str]]
+
+    def __repr__(self):
+        return self.source_line

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -8,14 +8,19 @@ from typing import List, Optional, NamedTuple
 
 # Note: This requires python 3.7
 
+# why named tuple and not a class?
 Subject = collections.namedtuple("Subject", ["id", "label", "type", "fullname", "synonyms", "taxon"])
 Term = collections.namedtuple("Term", ["id", "taxon"])
+
+# this should be kept general for the general association class
 Aspect = enum.Enum("Aspect", {
     "F": "F",
     "P": "P",
     "C": "C"
     })
 Curie = typing.NewType("Curie", str)
+Provider = typing.NewType("Provider", str)
+Date = typing.NewType("Date", str) ## actual datetime object is false precision
 
 class Evidence(NamedTuple):
     type: Curie # Curie of the ECO class
@@ -44,14 +49,14 @@ class Association:
     relation: Curie # This is the relation Curie
     object: Term
     negated: bool
-    qualifiers: List[str]
+    qualifiers: List[Curie]
     aspect: Aspect
     interacting_taxon: Optional[Curie]
     evidence: Evidence
     subject_extensions: List[ExtensionUnit]
     object_extensions: ExtensionExpression
-    provided_by: str
-    date: datetime.datetime
+    provided_by: Provider
+    date: Date
     properties: Dict[Curie, List[str]]
 
     def __repr__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pytest_logging>=0.0
 pydotplus>=0.0
 cachier==1.1.8
 plotly==2.0.7
+dataclasses==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ pytest_logging>=0.0
 pydotplus>=0.0
 cachier==1.1.8
 plotly==2.0.7
-dataclasses==0.6

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setuptools.setup(
         'scipy',
         'pandas',
         'click',
-        'yamldown'
+        'yamldown',
+        'dataclasses==0.6'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setuptools.setup(
         'scipy',
         'pandas',
         'click',
-        'yamldown'
+        'yamldown',
+        'dataclasses'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR just codifies what we've been doing in the dictionary for a long time now. We could do some minimal refactoring over time to convert the parsers and writers to use this Association object rather than the dictionary. This ensures all parsers and writers are on the same page. 

With @dustine32 and I working on the code concurrently where gpad and gafs will need to ensure solid communication, we should have a typed go-between structure. This is just the same as the dictionary, just named now.

This particular PR doesn't change any behavior - Dustin and I will slowly add this in where relevant over time in the parser/writer. @dustine32 if there's anything else we need to add to the model to make your work okay, let's make sure we know about it here. And @cmungall, did I capture your intent with the original json/dict structure okay here? 

My biggest question is about the Subject Extensions. In the GAF spec at least, it says we can only have 0 or 1 entries of this. But in the dictionary this is a list. Since I also know you are going for a higher level generalized form here for the subject extensions, I wanted to get your input that this is per your envisioning. 