### PR TITLE
Move get_owlsim_stats out of owlsim api class

### DIFF
--- a/ontobio/ontol_factory.py
+++ b/ontobio/ontol_factory.py
@@ -75,7 +75,7 @@ class OntologyFactory():
             return default_ontology
         return create_ontology(handle, **args)
 
-#@cachier(stale_after=SHELF_LIFE)
+@cachier(stale_after=SHELF_LIFE)
 def create_ontology(handle=None, **args):
     ont = None
     logging.info("Determining strategy to load '{}' into memory...".format(handle))

--- a/tests/test_phenosim_engine.py
+++ b/tests/test_phenosim_engine.py
@@ -39,8 +39,9 @@ class TestPhenoSimEngine():
     """
 
     @classmethod
-    @patch.object(OwlSim2Api, '_get_owlsim_stats',  MagicMock(return_value=(None, None)))
     def setup_class(self):
+
+        patch('ontobio.sim.api.owlsim2.get_owlsim_stats',  return_value=(None, None)).start()
 
         self.resolve_mock = patch.object(PhenoSimEngine, '_resolve_nodes_to_phenotypes',
                                          side_effect=mock_resolve_nodes)

--- a/tests/test_phenosim_engine.py
+++ b/tests/test_phenosim_engine.py
@@ -1,9 +1,9 @@
 from ontobio.sim.phenosim_engine import PhenoSimEngine
-from ontobio.sim.api.owlsim2 import OwlSim2Api, search_by_attribute_set
+from ontobio.sim.api.owlsim2 import OwlSim2Api
 from ontobio.vocabulary.similarity import SimAlgorithm
 from ontobio.model.similarity import IcStatistic
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 import os
 import json
 

--- a/tests/unit/test_annotation_scorer.py
+++ b/tests/unit/test_annotation_scorer.py
@@ -1,7 +1,7 @@
 from ontobio.sim.annotation_scorer import AnnotationScorer
 from ontobio.sim.api.owlsim2 import OwlSim2Api
 from ontobio.model.similarity import IcStatistic
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestAnnotationSufficiency():
@@ -14,8 +14,8 @@ class TestAnnotationSufficiency():
     """
 
     @classmethod
-    @patch.object(OwlSim2Api, '_get_owlsim_stats',  MagicMock(return_value=(None, None)))
     def setup_class(self):
+        patch('ontobio.sim.api.owlsim2.get_owlsim_stats',  return_value=(None, None)).start()
         self.ic_store = OwlSim2Api()
         self.annot_scorer = AnnotationScorer(self.ic_store)
 

--- a/tests/unit/test_owlsim2_api.py
+++ b/tests/unit/test_owlsim2_api.py
@@ -1,6 +1,6 @@
 from ontobio.sim.api.owlsim2 import OwlSim2Api
 from ontobio.vocabulary.similarity import SimAlgorithm
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class TestOwlSim2Api():

--- a/tests/unit/test_owlsim2_api.py
+++ b/tests/unit/test_owlsim2_api.py
@@ -9,8 +9,8 @@ class TestOwlSim2Api():
     """
 
     @classmethod
-    @patch.object(OwlSim2Api, '_get_owlsim_stats',  MagicMock(return_value=(None, None)))
     def setup_class(self):
+        patch('ontobio.sim.api.owlsim2.get_owlsim_stats',  return_value=(None, None)).start()
         self.sim_api = OwlSim2Api()
 
     @classmethod


### PR DESCRIPTION
- Uncomments caching in ontology factory
- Moves get_owlsim_stats into module scope instead of class (should I turn the whole thing into a module)?

Fixes https://github.com/biolink/biolink-api/issues/251