### PR TITLE
Specify PyYaml version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     install_requires=[
         'networkx==2.2',
         'jsobject',
-        'pyyaml>=4.2b1',
+        'pyyaml==4.2b1',
         'pysolr',
         'requests',
         'sparqlwrapper',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     install_requires=[
         'networkx==2.2',
         'jsobject',
-        'pyyaml==4.2b1',
+        'pyyaml==4.2b4',
         'pysolr',
         'requests',
         'sparqlwrapper',


### PR DESCRIPTION
We should fix our yaml.load calls -  https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

But in the short term this will allow to run biolink-api