### PR TITLE
Fix pyyaml usage

### DIFF
--- a/bin/ontobio-lexmap.py
+++ b/bin/ontobio-lexmap.py
@@ -87,7 +87,7 @@ def main():
     config = {}
     if args.config is not None:
         f = open(args.config,'r')
-        config = yaml.load(f)
+        config = yaml.load(f, Loader=yaml.FullLoader)
         f.close()
 
     # add pre-defined weights to config

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -64,7 +64,7 @@ def metadata_file(metadata, group) -> Dict:
     try:
         with open(metadata_yaml, "r") as group_data:
             click.echo("Found {group} metadata at {path}".format(group=group, path=metadata_yaml))
-            return yaml.load(group_data)
+            return yaml.load(group_data, Loader=yaml.FullLoader)
     except Exception as e:
         raise click.ClickException("Could not find or read {}: {}".format(metadata_yaml, str(e)))
 
@@ -148,7 +148,7 @@ def database_entities(metadata) -> Set[str]:
     try:
         with open(dbxrefs_path, "r") as db_xrefs_file:
             click.echo("Found db-xrefs at {path}".format(path=dbxrefs_path))
-            dbxrefs = yaml.load(db_xrefs_file)
+            dbxrefs = yaml.load(db_xrefs_file, Loader=yaml.FullLoader)
     except Exception as e:
         raise click.ClickException("Could not find or read {}: {}".format(dbxrefs_path, str(e)))
 
@@ -159,7 +159,7 @@ def groups(metadata) -> Set[str]:
     try:
         with open(groups_path, "r") as groups_file:
             click.echo("Found groups at {path}".format(path=groups_path))
-            groups_list = yaml.load(groups_file)
+            groups_list = yaml.load(groups_file, Loader=yaml.FullLoader)
     except Exception as e:
         raise click.ClickException("Could not find or read {}: {}".format(groups_path, str(e)))
 

--- a/ontobio/config.py
+++ b/ontobio/config.py
@@ -227,7 +227,7 @@ def reset_config():
 
 def load_config(path):
     f = open(path,'r')
-    obj = yaml.load(f)
+    obj = yaml.load(f, Loader=yaml.FullLoader)
     schema = ConfigSchema()
     config = schema.load(obj).data
     errs = schema.validate(obj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pydotplus>=0.0
 cachier==1.1.8
 plotly==2.0.7
 pyyaml==5.1b3
+yamldown>=0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pytest_logging>=0.0
 pydotplus>=0.0
 cachier==1.1.8
 plotly==2.0.7
+pyyaml==5.1b3

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
         'scipy',
         'pandas',
         'click',
-        'yamldown'
+        'yamldown>=0.1.7'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     install_requires=[
         'networkx==2.2',
         'jsobject',
-        'pyyaml==4.2b4',
+        'pyyaml==5.1b3',
         'pysolr',
         'requests',
         'sparqlwrapper',


### PR DESCRIPTION
This PR is as a result of changes in PyYAML 5.1.
Using `yaml.load()` without specifying a loader is not secure.

More details here: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

This PR depends on https://github.com/dougli1sqrd/yamldown/pull/4
