### PR TITLE
Adds 'aspect' field to object of an association

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -1450,6 +1450,7 @@ class GolrAssociationQuery(GolrAbstractQuery):
 
         if 'aspect' in d and id.startswith('GO:'):
             obj['aspect'] = ASPECT_MAP[d['aspect']]
+            del d['aspect']
 
         cf = fname + "_category"
         if cf in d:

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -171,9 +171,9 @@ INVERT_FIELDS_MAP = {
 }
 
 ASPECT_MAP = {
-    'F': 'molecular_activity',
-    'P': 'biological_process',
-    'C': 'cellular_component'
+    'F': 'GO:0003674',
+    'P': 'GO:0008150',
+    'C': 'GO:0005575'
 }
 
 
@@ -1448,6 +1448,10 @@ class GolrAssociationQuery(GolrAbstractQuery):
         if lf in d:
             obj['label'] = d[lf]
 
+        if 'aspect' in d and id.startswith('GO:'):
+            obj['aspect'] = ASPECT_MAP[d['aspect']]
+            del d['aspect']
+
         cf = fname + "_category"
         if cf in d:
             obj['categories'] = [d[cf]]
@@ -1531,10 +1535,6 @@ class GolrAssociationQuery(GolrAbstractQuery):
         if M.EVIDENCE_OBJECT in d:
             assoc['evidence'] = d[M.EVIDENCE_OBJECT]
             assoc['types'] = [t for t in d[M.EVIDENCE_OBJECT] if t.startswith('ECO:')]
-
-        if M.ASPECT in d:
-            assoc[M.OBJECT_CATEGORY] = ASPECT_MAP[d[M.ASPECT]]
-            del d[M.ASPECT]
 
         if self._use_amigo_schema(self.object_category):
             for f in M.AMIGO_SPECIFIC_FIELDS:

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -171,9 +171,9 @@ INVERT_FIELDS_MAP = {
 }
 
 ASPECT_MAP = {
-    'F': 'GO:0003674',
-    'P': 'GO:0008150',
-    'C': 'GO:0005575'
+    'F': 'molecular_activity',
+    'P': 'biological_process',
+    'C': 'cellular_component'
 }
 
 
@@ -1449,7 +1449,7 @@ class GolrAssociationQuery(GolrAbstractQuery):
             obj['label'] = d[lf]
 
         if 'aspect' in d and id.startswith('GO:'):
-            obj['aspect'] = ASPECT_MAP[d['aspect']]
+            obj['category'] = ASPECT_MAP[d['aspect']]
             del d['aspect']
 
         cf = fname + "_category"

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -1195,7 +1195,7 @@ class GolrAssociationQuery(GolrAbstractQuery):
 
         facet_fields = [ map_field(fn, self.field_mapping) for fn in facet_fields ]
 
-        if self._use_amigo_schema:
+        if self._use_amigo_schema(object_category):
             select_fields += [x for x in M.AMIGO_SPECIFIC_FIELDS if x not in select_fields]
 
         ## true if iterate in windows of max_size until all results found
@@ -1524,7 +1524,7 @@ class GolrAssociationQuery(GolrAbstractQuery):
             assoc['evidence'] = d[M.EVIDENCE_OBJECT]
             assoc['types'] = [t for t in d[M.EVIDENCE_OBJECT] if t.startswith('ECO:')]
 
-        if self._use_amigo_schema:
+        if self._use_amigo_schema(self.object_category):
             for f in M.AMIGO_SPECIFIC_FIELDS:
                 if f in d:
                     assoc[f] = d[f]

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -111,7 +111,7 @@ class GolrFields:
     EVIDENCE_OBJECT_LABEL='evidence_object_label'
     _VERSION_='_version_'
     SUBJECT_GENE_CLOSURE_LABEL_SEARCHABLE='subject_gene_closure_label_searchable'
-
+    ASPECT='aspect'
     RELATION='relation'
     RELATION_LABEL='relation_label'
 
@@ -134,7 +134,8 @@ class GolrFields:
         'evidence_subset_closure',
         'evidence_subset_closure_label',
         'evidence_type_closure',
-        'evidence_type_closure_label'
+        'evidence_type_closure_label',
+        'aspect'
     ]
 
     # golr convention: for any entity FOO, the id is denoted 'foo'
@@ -168,6 +169,13 @@ INVERT_FIELDS_MAP = {
     M.SUBJECT_TAXON_LABEL: M.OBJECT_TAXON_LABEL,
     M.SUBJECT_CLOSURE_MAP: M.OBJECT_CLOSURE_MAP,
 }
+
+ASPECT_MAP = {
+    'F': 'GO:0003674',
+    'P': 'GO:0008150',
+    'C': 'GO:0005575'
+}
+
 
 # normalize to what Monarch uses
 PREFIX_NORMALIZATION_MAP = {
@@ -1439,6 +1447,9 @@ class GolrAssociationQuery(GolrAbstractQuery):
 
         if lf in d:
             obj['label'] = d[lf]
+
+        if 'aspect' in d and id.startswith('GO:'):
+            obj['aspect'] = ASPECT_MAP[d['aspect']]
 
         cf = fname + "_category"
         if cf in d:

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -171,9 +171,9 @@ INVERT_FIELDS_MAP = {
 }
 
 ASPECT_MAP = {
-    'F': 'GO:0003674',
-    'P': 'GO:0008150',
-    'C': 'GO:0005575'
+    'F': 'molecular_activity',
+    'P': 'biological_process',
+    'C': 'cellular_component'
 }
 
 
@@ -1448,10 +1448,6 @@ class GolrAssociationQuery(GolrAbstractQuery):
         if lf in d:
             obj['label'] = d[lf]
 
-        if 'aspect' in d and id.startswith('GO:'):
-            obj['aspect'] = ASPECT_MAP[d['aspect']]
-            del d['aspect']
-
         cf = fname + "_category"
         if cf in d:
             obj['categories'] = [d[cf]]
@@ -1535,6 +1531,10 @@ class GolrAssociationQuery(GolrAbstractQuery):
         if M.EVIDENCE_OBJECT in d:
             assoc['evidence'] = d[M.EVIDENCE_OBJECT]
             assoc['types'] = [t for t in d[M.EVIDENCE_OBJECT] if t.startswith('ECO:')]
+
+        if M.ASPECT in d:
+            assoc[M.OBJECT_CATEGORY] = ASPECT_MAP[d[M.ASPECT]]
+            del d[M.ASPECT]
 
         if self._use_amigo_schema(self.object_category):
             for f in M.AMIGO_SPECIFIC_FIELDS:


### PR DESCRIPTION
This PR addresses the request for adding a field that refers to the aspect of a GO term in an association.

Instead of `aspect` we use `category` to describe what category the GO term belongs to.

This `category` field can have one of three values: 
* `molecular_activity` (F)
* `biological_process` (P)
* `cellular_component` (C)

These values are valid BioLink Model types.

This addition is only applied when associations are fetched from AmiGO/GOlr.

Ex:
```
{
"subject": "UniProtKB:P60484",
"slim": "GO:0008150",
"assocs": [
	{
	"id": "556e6950726f744b4209503630343834095054454e0909474f3a3030303030373909504d49443a3130393138353639095441530909500950686f73706861746964796c696e6f7369746f6c20332c342c352d7472697370686f73706861746520332d70686f737068617461736520616e64206475616c2d73706563696669636974792070726f7465696e2070686f7370686174617365205054454e094d4d4143317c544550310970726f7465696e097461786f6e3a3936303609323030353131303909556e6950726f74090909",
	"subject": {
		"id": "HGNC:9588",
		"label": "PTEN",
		"taxon": {
			"id": "NCBITaxon:9606",
			"label": "Homo sapiens"
		}
	},
	"object": {
		"id": "GO:0000079",
		"label": "regulation of cyclin-dependent protein serine/threonine kinase activity"
        	"category": "biological_process",
	},
...
}
```


Original request: https://github.com/biolink/biolink-api/issues/238