### PR TITLE
command line option to suppress messages from rules with specified tags

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -203,7 +203,7 @@ def groups(metadata) -> Set[str]:
 Produce validated gaf using the gaf parser/
 """
 @gzips
-def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None, paint=False, group="unknown", rule_metadata=None, db_entities=None, group_idspace=None, suppress_rule_tags=[]):
+def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None, paint=False, group="unknown", rule_metadata=None, db_entities=None, group_idspace=None, suppress_rule_reporting_tags=[]):
     filtered_associations = open(os.path.join(os.path.split(source_gaf)[0], "{}_noiea.gaf".format(dataset)), "w")
 
     config = assocparser.AssocParserConfig(
@@ -215,7 +215,7 @@ def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None, paint=False, 
         rule_metadata=rule_metadata,
         entity_idspaces=db_entities,
         group_idspace=group_idspace,
-        suppress_rule_tags=suppress_rule_tags
+        suppress_rule_reporting_tags=suppress_rule_reporting_tags
     )
     validated_gaf_path = os.path.join(os.path.split(source_gaf)[0], "{}_valid.gaf".format(dataset))
     outfile = open(validated_gaf_path, "w")
@@ -406,8 +406,8 @@ def cli():
 @click.option("--ontology", "-o", type=click.Path(exists=True), required=False)
 @click.option("--exclude", "-x", multiple=True)
 @click.option("--base-download-url", "-b", default=None)
-@click.option("--suppress-rule-tag", multiple=True, help="Suppress markdown output messages from rules tagged with this tag")
-def produce(group, metadata, gpad, ttl, target, ontology, exclude, base_download_url, suppress_rule_tag):
+@click.option("--suppress-rule-reporting-tag", multiple=True, help="Suppress markdown output messages from rules tagged with this tag")
+def produce(group, metadata, gpad, ttl, target, ontology, exclude, base_download_url, suppress_rule_reporting_tag):
 
     products = {
         "gaf": True,
@@ -447,7 +447,7 @@ def produce(group, metadata, gpad, ttl, target, ontology, exclude, base_download
             rule_metadata=rule_metadata,
             db_entities=db_entities,
             group_idspace=group_ids,
-            suppress_rule_tags=suppress_rule_tag)[0]
+            suppress_rule_reporting_tags=suppress_rule_reporting_tag)[0]
 
         gpi = produce_gpi(dataset, absolute_target, valid_gaf, ontology_graph)
 

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -145,6 +145,8 @@ class Report():
         self.n_assocs = 0
         self.skipped = 0
         self.reporter = parsereport.Report(group, dataset)
+        if config is None:
+            config = AssocParserConfig()
         self.config = config
         self.header = []
 

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -78,7 +78,7 @@ class AssocParserConfig():
                  paint=False,
                  rule_metadata=None,
                  dbxrefs=None,
-                 suppress_rule_tags=[]):
+                 suppress_rule_reporting_tags=[]):
 
         self.remove_double_prefixes=remove_double_prefixes
         self.ontology=ontology
@@ -94,7 +94,7 @@ class AssocParserConfig():
         self.gpi_authority_path = gpi_authority_path
         self.paint = paint
         self.rule_metadata = rule_metadata
-        self.suppress_rule_tags = suppress_rule_tags
+        self.suppress_rule_reporting_tags = suppress_rule_reporting_tags
 
         self.entity_idspaces = None if entity_idspaces is None else set(entity_idspaces)
         self.group_idspace = None if group_idspace is None else set(group_idspace)
@@ -225,7 +225,7 @@ class Report():
         ## Table of Contents
         s += "\n\n## Contents\n\n"
         for rule, messages in sorted(json["messages"].items(), key=lambda t: t[0]):
-            any_suppress_tag_in_rule_metadata = any([tag in self.config.rule_metadata.get(rule, {}).get("tags", []) for tag in self.config.suppress_rule_tags])
+            any_suppress_tag_in_rule_metadata = any([tag in self.config.rule_metadata.get(rule, {}).get("tags", []) for tag in self.config.suppress_rule_reporting_tags])
             # For each tag we say to suppress output for, check if it matches any tag in the rule. If any matches
             if self.config.rule_metadata and any_suppress_tag_in_rule_metadata:
                 continue
@@ -234,7 +234,7 @@ class Report():
 
         s += "\n## MESSAGES\n\n"
         for (rule, messages) in sorted(json["messages"].items(), key=lambda t: t[0]):
-            any_suppress_tag_in_rule_metadata = any([tag in self.config.rule_metadata.get(rule, {}).get("tags", []) for tag in self.config.suppress_rule_tags])
+            any_suppress_tag_in_rule_metadata = any([tag in self.config.rule_metadata.get(rule, {}).get("tags", []) for tag in self.config.suppress_rule_reporting_tags])
 
             # Skip if the rule metadata has "silent" as a tag
             if self.config.rule_metadata and any_suppress_tag_in_rule_metadata:

--- a/ontobio/io/entityparser.py
+++ b/ontobio/io/entityparser.py
@@ -7,6 +7,7 @@ import json
 
 # TODO - use abstract parent for both entity and assoc
 class EntityParser(AssocParser):
+
     def parse(self, file, outfile=None):
         """Parse a line-oriented entity file into a list of entity dict objects
 
@@ -63,7 +64,7 @@ class EntityParser(AssocParser):
 
 class GpiParser(EntityParser):
 
-    def __init__(self,config=None):
+    def __init__(self, config=None):
         """
         Arguments:
         ---------
@@ -72,7 +73,10 @@ class GpiParser(EntityParser):
         """
         if config is None:
             config = AssocParserConfig()
+            print("We created a GPI config object")
+
         self.config = config
+        print("init, config = {}".format(config))
         self.report = Report()
 
     def parse_line(self, line):

--- a/ontobio/io/parsereport.py
+++ b/ontobio/io/parsereport.py
@@ -10,7 +10,7 @@ class Report(object):
     def __init__(self, group, dataset):
         self.group = group
         self.dataset = dataset
-        self.messages = {} # type: Dict[str, List[Message]]
+        self.messages = {} # type: Dict[str, List[Message]] # rule id --> List of messages
         self.messages["other"] = []
         self._rule_message_cap = 10000
 


### PR DESCRIPTION
`validate.py produce` now has an option `--suppress-rule-tag tag`. This will suppress messages generated from rules with the tag `tag`. Default is no suppression of messages. The canonical thing to do will be to use this with `silent`, which gorule 26 currently has - which will suppress markdown report of rule 26. 

See also https://github.com/geneontology/go-site/issues/884