### PR TITLE
ontology creation for validate script no longer uses cachier

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -547,7 +547,7 @@ def produce(group, metadata, gpad, ttl, target, ontology, exclude, base_download
 
     group_metadata = metadata_file(absolute_metadata, group)
     click.echo("Loading ontology: {}...".format(ontology))
-    ontology_graph = OntologyFactory().create(ontology)
+    ontology_graph = OntologyFactory().create(ontology, ignore_cache=True)
 
     downloaded_gaf_sources = download_source_gafs(group_metadata, absolute_target, exclusions=exclude, base_download_url=base_download_url)
     # dict of Dataset Metadata --> downloaded source paths (unzipped)


### PR DESCRIPTION
We don't get benefit in the pipeline from cachier in ontology loading as we only load the ontology once per process. Addionally, cachier is hiccuping in the pipeline, so we will attempt to not cache as a solution.