### PR TITLE
Return subject and object iri and category when fetching associations

### DIFF
--- a/ontobio/config.yaml
+++ b/ontobio/config.yaml
@@ -20,7 +20,7 @@ scigraph_ontology:
   url: "https://scigraph-ontology.monarchinitiative.org/scigraph/"
   timeout: 15
 scigraph_data:
-  url: "https://scigraph-data.monarchinitiative.org/scigraph/"
+  url: "https://scigraph-data.monarchinitiative.org/scigraph"
   timeout: 15
 owlsim2:
   url: "https://monarchinitiative.org/owlsim/"

--- a/ontobio/golr/golr_associations.py
+++ b/ontobio/golr/golr_associations.py
@@ -22,7 +22,8 @@ def get_association(id, **kwargs):
     Fetch an association object by ID
     """
     results = search_associations(id=id, **kwargs)
-    return results['associations'][0]
+    assoc = results['associations'][0] if len(results['associations']) > 0 else {}
+    return assoc
 
 def search_associations(**kwargs):
 

--- a/ontobio/util/scigraph_util.py
+++ b/ontobio/util/scigraph_util.py
@@ -5,7 +5,8 @@ from typing import List, Dict, Iterator, Iterable, Optional
 from json.decoder import JSONDecodeError
 from ontobio.ontol_factory import OntologyFactory
 from ontobio.model.similarity import Node, TypedNode
-
+import requests
+from cachier import cachier
 
 def namespace_to_taxon() -> Dict[str, Node]:
     """
@@ -162,3 +163,17 @@ def typed_node_from_id(id: str) -> TypedNode:
         type=types[0],
         taxon = get_taxon(id)
     )
+
+@cachier()
+def get_curie_map(url):
+    """
+    Get CURIE prefix map from SciGraph cypher/curies endpoint
+    """
+    curie_map = {}
+    response = requests.get(url)
+    if response.status_code == 200:
+        curie_map = response.json()
+    else:
+        curie_map = {}
+
+    return curie_map


### PR DESCRIPTION
This PR adds subject and object `iri` and `category` when fetching associations via golr_query.

CURIE to IRI conversion is done using prefix map as provided by `scigraph-data` instance.
