### PR TITLE
rule 33 impl only reports, does not repair

### DIFF
--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -655,20 +655,15 @@ class AssocParser(object):
         okay_ref = []
         for ref in references:
             prefix = ref.split(":", maxsplit=1)[0]
-            if prefix in allowed_prefixes:
-                # then we found a good ref, so we'll keep it
-                okay_ref.append(ref)
-            else:
+            if prefix not in allowed_prefixes:
+                # then we found a bad ref, so we'll record it
                 found_bad_refs.append(ref)
 
         if found_bad_refs:
             self.report.warning(line.line, Report.INVALID_IDSPACE, ", ".join(found_bad_refs), "References should only be from ID prefixes PMID, PMD, doi, or GO_REF", rule=33)
 
-        # If we only have bad references, just pass it through
-        if len(okay_ref) == 0:
-            return references
-        else:
-            return okay_ref
+        # We are only reporting, so just pass it through
+        return references
 
     def _normalize_id(self, id):
         toks = id.split(":")

--- a/tests/test_parse_ids.py
+++ b/tests/test_parse_ids.py
@@ -118,7 +118,6 @@ def test_normalize_refs_many_bad_refs():
 def test_normalize_refs_good_and_bad_refs():
     parser = gafparser.GafParser()
     refs = parser.normalize_refs(["FB:123", "PMID:234"], assocparser.SplitLine("", [""]*17, "taxon:foo"))
-    assert refs == ["PMID:234"]
     assert len(parser.report.messages) == 1
     assert parser.report.messages[0]["type"] == assocparser.Report.INVALID_IDSPACE
 


### PR DESCRIPTION
Per the changes to gorule 33 to make it report only, this makes no changes to the references.