### PR TITLE
Prioritize primary label when returning best highlight

### DIFF
--- a/tests/unit/resources/solr/input/solr-docs.json
+++ b/tests/unit/resources/solr/input/solr-docs.json
@@ -23,6 +23,9 @@
     "SGD:S000004154":{
       "label_eng":[
         "<em class=\"hilite\">SHH4</em>"
+      ],
+      "synonym_kw":[
+        "<em class=\"hilite\">SHH44</em>"
       ]
     },
     "SGD:S000004724":{

--- a/tests/unit/test_golr_search_query.py
+++ b/tests/unit/test_golr_search_query.py
@@ -210,9 +210,8 @@ class TestGolrSearchParams():
             'MONDO'
         ]
         expected = [
-            '-prefix:"OMIA"',
-            '-prefix:"Orphanet"',
-            'prefix:"DO" OR prefix:"OMIM" OR prefix:"MONDO"'
+            'prefix:(-OMIA AND -Orphanet)',
+            'prefix:("DO" OR "OMIM" OR "MONDO")'
         ]
         self.manager.prefix = prefix_filter
         params = self.manager.solr_params()


### PR DESCRIPTION
Updates highlight code that selects the "best" highlight from a list of matches to a document in solr.  The code now prioritizes primary labels if available, and then looks for the longest match thereafter.  Fixes https://github.com/monarch-initiative/monarch-ui/issues/69