### PR TITLE
Introduced "ignore_cache" flag in ontobio/config.yaml (defaults to 'False') 

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,13 @@ The development version can be downloaded from GitHub.
     pip install -e .[dev,test]
 
 
+Alternately, pip can be directly used to install the master (or other) branch from git, as a pip requirement:
+
+::
+
+    pip install git+https://github.com/biolink/ontobio@master#egg=ontobio
+
+
 With pyvenv
 -----------
 

--- a/docs/ontologies_advanced.rst
+++ b/docs/ontologies_advanced.rst
@@ -3,4 +3,18 @@
 Advanced Ontology Use
 =====================
 
-**TODO**
+The ontobio/config.yaml file contains settings which could be overidden (generally unnecessary).
+
+Ignoring the Cache
+------------------
+
+Ontobio uses the Python Cachier library to enhance performance for some applications but there may be instances
+when you wish to turn the caching off (e.g. if you are just reading a whole ontology into memory then working
+with it, without modifying it or accessing it again from its remote source).  To disable caching, you set the
+ignore_cache flag in the config.yaml file to 'True' (default: False).  The easiest, non-invasive way to achieve this
+is to run this at a global location in your code during startup and before accessing any ontology:
+
+::
+
+    from ontobio.config import session
+    session.config.ignore_cache = True

--- a/ontobio/assoc_factory.py
+++ b/ontobio/assoc_factory.py
@@ -4,13 +4,12 @@ Factory class for generating association sets based on a variety of handle types
 Currently only supports golr query
 """
 
-import networkx as nx
 import pathlib
 import logging
-import os
-import subprocess
-import hashlib
+
+from ontobio.config import get_config
 from cachier import cachier
+
 import datetime
 from ontobio.golr.golr_associations import bulk_fetch
 from ontobio.assocmodel import AssociationSet, AssociationSetMetadata
@@ -32,6 +31,7 @@ class AssociationSetFactory():
         """
         initializes based on an ontology name
         """
+        self.config = get_config()
 
     def create(self, ontology=None,subject_category=None,object_category=None,evidence=None,taxon=None,relation=None, file=None, fmt=None, skim=True):
         """
@@ -64,7 +64,8 @@ class AssociationSetFactory():
         assocs = bulk_fetch_cached(subject_category=subject_category,
                                    object_category=object_category,
                                    evidence=evidence,
-                                   taxon=taxon)
+                                   taxon=taxon,
+                                   ignore_cache=self.config.ignore_cache)
 
         logging.info("Creating map for {} subjects".format(len(assocs)))
 

--- a/ontobio/config.py
+++ b/ontobio/config.py
@@ -41,6 +41,7 @@ class ConfigSchema(Schema):
     """
     Marshmallow schema for configuration objects.
     """
+    ignore_cache = fields.Nested(EndpointSchema)
     sparql = fields.Nested(EndpointSchema, description="SPARQL URL to use for ontology queries")
     solr_assocs = fields.Nested(EndpointSchema)
     solr_search = fields.Nested(EndpointSchema)
@@ -66,8 +67,8 @@ class Endpoint():
     RESTish endpoint
     """
     def __init__(self,
-                 url = None,
-                 timeout = None):
+                 url=None,
+                 timeout=None):
         self.url = url
         self.timeout = timeout
 
@@ -76,20 +77,20 @@ class OntologyConfig():
     Maps local id of ontology to a handle
     """
     def __init__(self,
-                 id = None,
-                 handle = None,
-                 pre_load = False):
+                 id=None,
+                 handle=None,
+                 pre_load=False):
         self.id = id
         self.handle = handle
-        self.pre_load  = pre_load
+        self.pre_load = pre_load
 
 class Category():
     """
     Maps category to class
     """
     def __init__(self,
-                 id = None,
-                 superclass = None):
+                 id=None,
+                 superclass=None):
         self.id = id
         self.superclass = superclass
 
@@ -100,21 +101,23 @@ class Config():
 
     """
     def __init__(self,
-                 solr_assocs = None,
-                 amigo_solr_assocs = None,
-                 solr_search = None,
-                 amigo_solr_search = None,
-                 lay_person_search = None,
-                 sparql = None,
-                 scigraph_ontology = None,
-                 scigraph_data = None,
-                 owlsim2 = None,
-                 owlsim3 = None,
-                 ontologies = None,
-                 categories = None,
-                 default_solr_schema = None,
-                 use_amigo_for = "function",
-                 taxon_restriction = None):
+                 ignore_cache=None,
+                 solr_assocs=None,
+                 amigo_solr_assocs=None,
+                 solr_search=None,
+                 amigo_solr_search=None,
+                 lay_person_search=None,
+                 sparql=None,
+                 scigraph_ontology=None,
+                 scigraph_data=None,
+                 owlsim2=None,
+                 owlsim3=None,
+                 ontologies=None,
+                 categories=None,
+                 default_solr_schema=None,
+                 use_amigo_for="function",
+                 taxon_restriction=None):
+        self.ignore_cache = ignore_cache
         self.solr_assocs = solr_assocs
         self.amigo_solr_assocs = amigo_solr_assocs
         self.solr_search = solr_search

--- a/ontobio/config.py
+++ b/ontobio/config.py
@@ -41,7 +41,7 @@ class ConfigSchema(Schema):
     """
     Marshmallow schema for configuration objects.
     """
-    ignore_cache = fields.Nested(EndpointSchema)
+    ignore_cache = fields.Boolean()
     sparql = fields.Nested(EndpointSchema, description="SPARQL URL to use for ontology queries")
     solr_assocs = fields.Nested(EndpointSchema)
     solr_search = fields.Nested(EndpointSchema)

--- a/ontobio/config.yaml
+++ b/ontobio/config.yaml
@@ -1,3 +1,6 @@
+# Enable caching of ontology in the code base
+ignore_cache: True
+#
 solr_assocs:
   url: "https://solr.monarchinitiative.org/solr/golr"
   timeout: 60

--- a/ontobio/config.yaml
+++ b/ontobio/config.yaml
@@ -1,5 +1,5 @@
 # Enable caching of ontology in the code base
-ignore_cache: True
+ignore_cache: False
 #
 solr_assocs:
   url: "https://solr.monarchinitiative.org/solr/golr"

--- a/ontobio/ecomap.py
+++ b/ontobio/ecomap.py
@@ -1,6 +1,9 @@
 import requests
 from contextlib import closing
+
+from ontobio.config import get_config
 from cachier import cachier
+
 import datetime
 import logging
 
@@ -32,10 +35,11 @@ class EcoMap():
 
     def __init__(self):
         self._mappings = None
+        self.config = get_config()
     
     def mappings(self):
         if self._mappings is None:
-            s = get_ecomap_str(self.PURL)
+            s = get_ecomap_str(self.PURL, ignore_cache=self.config.ignore_cache)
             self._mappings = self.parse_ecomap_str(s)
         return self._mappings
 

--- a/ontobio/ontol_factory.py
+++ b/ontobio/ontol_factory.py
@@ -4,16 +4,18 @@ Factory class for generating ontology objects based on a variety of handle types
 See :ref:`inputs` on readthedocs for more details
 """
 
-import networkx as nx
 import logging
 import ontobio.obograph_util as obograph_util
-import ontobio.sparql.sparql_ontology
+
 from ontobio.ontol import Ontology
 from ontobio.sparql.sparql_ontology import EagerRemoteSparqlOntology
 import os
 import subprocess
 import hashlib
+
+from ontobio.config import get_config
 from cachier import cachier
+
 import datetime
 
 SHELF_LIFE = datetime.timedelta(days=3)
@@ -47,6 +49,7 @@ class OntologyFactory():
             see `create`
         """
         self.handle = handle
+        self.config = get_config()
 
     def create(self, handle=None, handle_type=None, **args):
         """
@@ -70,10 +73,10 @@ class OntologyFactory():
             global default_ontology
             if default_ontology is None:
                 logging.info("Creating new instance of default ontology")
-                default_ontology = create_ontology(default_ontology_handle)
+                default_ontology = create_ontology(default_ontology_handle, ignore_cache=self.config.ignore_cache)
             logging.info("Using default_ontology")
             return default_ontology
-        return create_ontology(handle, **args)
+        return create_ontology(handle, ignore_cache=self.config.ignore_cache, **args)
 
 @cachier(stale_after=SHELF_LIFE)
 def create_ontology(handle=None, **args):
@@ -82,7 +85,10 @@ def create_ontology(handle=None, **args):
 
     if handle.find("+") > -1:
         handles = handle.split("+")
-        onts = [create_ontology(ont) for ont in handles]
+        # RMB: 3-Jun-2019: appending the **args to
+        # this recursive call of create_ontology,
+        # just in case they are relevant?
+        onts = [create_ontology(ont, **args) for ont in handles]
         ont = onts.pop()
         ont.merge(onts)
         return ont

--- a/ontobio/sparql/sparql_ontol_utils.py
+++ b/ontobio/sparql/sparql_ontol_utils.py
@@ -69,15 +69,15 @@ def get_digraph(ont, relations=None, writecache=False):
     """
     Creates a basic graph object corresponding to a remote ontology
     """
-
+    config = get_config()
     digraph = networkx.MultiDiGraph()
     logging.info("Getting edges (may be cached)")
-    for (s,p,o) in get_edges(ont, ignore_cache=get_config().ignore_cache):
+    for (s,p,o) in get_edges(ont, ignore_cache=config.ignore_cache):
         p = map_legacy_pred(p)
         if relations is None or p in relations:
             digraph.add_edge(o,s,pred=p)
     logging.info("Getting labels (may be cached)")
-    for (n,label) in fetchall_labels(ont):
+    for (n,label) in fetchall_labels(ont, ignore_cache=config.ignore_cache):
         digraph.add_node(n, **{'label':label})
     return digraph
 
@@ -86,8 +86,8 @@ def get_xref_graph(ont):
     Creates a basic graph object corresponding to a remote ontology
     """
     g = networkx.MultiGraph()
-    for (c,x) in fetchall_xrefs(ont):
-        g.add_edge(c,x,source=c)
+    for (c, x) in fetchall_xrefs(ont, ignore_cache=get_config().ignore_cache):
+        g.add_edge(c, x, source=c)
     return g
 
 
@@ -97,7 +97,7 @@ def get_edges(ont):
     Fetches all basic edges from a remote ontology
     """
     logging.info("QUERYING:"+ont)
-    edges = [(c,SUBCLASS_OF, d) for (c,d) in fetchall_isa(ont)]
+    edges = [(c, SUBCLASS_OF, d) for (c, d) in fetchall_isa(ont)]
     edges += fetchall_svf(ont)
     edges += [(c,SUBPROPERTY_OF, d) for (c,d) in fetchall_subPropertyOf(ont)]
     if len(edges) == 0:

--- a/ontobio/sparql/sparql_ontol_utils.py
+++ b/ontobio/sparql/sparql_ontol_utils.py
@@ -15,7 +15,10 @@ from prefixcommons.curie_util import contract_uri, expand_uri
 from ontobio.vocabulary.relations import map_legacy_pred
 from functools import lru_cache
 import networkx
+
+from ontobio.config import get_config
 from cachier import cachier
+
 import datetime
 import logging
 
@@ -66,9 +69,10 @@ def get_digraph(ont, relations=None, writecache=False):
     """
     Creates a basic graph object corresponding to a remote ontology
     """
+
     digraph = networkx.MultiDiGraph()
     logging.info("Getting edges (may be cached)")
-    for (s,p,o) in get_edges(ont):
+    for (s,p,o) in get_edges(ont, ignore_cache=get_config().ignore_cache):
         p = map_legacy_pred(p)
         if relations is None or p in relations:
             digraph.add_edge(o,s,pred=p)

--- a/ontobio/sparql/sparql_ontology.py
+++ b/ontobio/sparql/sparql_ontology.py
@@ -229,6 +229,8 @@ class EagerRemoteSparqlOntology(RemoteSparqlOntology):
         """
         initializes based on an ontology name
         """
+        super().__init__()
+
         self.id = get_named_graph(handle)
         self.handle = handle
         logging.info("Creating eager-remote-sparql from "+str(handle))
@@ -258,6 +260,7 @@ class LazyRemoteSparqlOntology(RemoteSparqlOntology):
     """
 
     def __init__(self):
+        super().__init__()
         self.all_logical_definitions = [] ## TODO
 
 

--- a/ontobio/sparql/sparql_ontology.py
+++ b/ontobio/sparql/sparql_ontology.py
@@ -12,9 +12,13 @@ Ontology
 
 import networkx as nx
 import logging
+
+from ontobio.config import get_config
+
 import ontobio.ontol
 from ontobio.ontol import Ontology, Synonym, TextDefinition
-from ontobio.sparql.sparql_ontol_utils import get_digraph, get_named_graph, get_xref_graph, run_sparql, fetchall_syns, fetchall_textdefs, fetchall_labels, fetchall_obs, OIO_SYNS
+from ontobio.sparql.sparql_ontol_utils import get_digraph, get_named_graph, get_xref_graph, run_sparql, \
+     fetchall_syns, fetchall_textdefs, fetchall_obs, OIO_SYNS
 from prefixcommons.curie_util import contract_uri, expand_uri, get_prefixes
 
 
@@ -22,6 +26,9 @@ class RemoteSparqlOntology(Ontology):
     """
     Local or remote ontology
     """
+
+    def __init__(self):
+        self.config = get_config()
 
     def extract_subset(self, subset):
         """
@@ -70,7 +77,7 @@ class RemoteSparqlOntology(Ontology):
     def all_text_definitions(self):
         logging.debug("Fetching all textdefs...")
         if self.all_text_definitions_cache is None:
-            vals = fetchall_textdefs(self.graph_name)
+            vals = fetchall_textdefs(self.graph_name, ignore_cache=self.config.ignore_cache)
             tds = [TextDefinition(c,v) for (c,v) in vals]
             for td in tds:
                 self.add_text_definition(td)
@@ -86,7 +93,7 @@ class RemoteSparqlOntology(Ontology):
     def all_obsoletes(self):
         logging.debug("Fetching all obsoletes...")
         if self.all_obsoletes_cache is None:
-            obsnodes = fetchall_obs(self.graph_name)
+            obsnodes = fetchall_obs(self.graph_name, ignore_cache=self.config.ignore_cache)
             for n in obsnodes:
                 self.set_obsolete(n)
             self.all_obsoletes_cache = obsnodes # TODO: check if still used
@@ -103,7 +110,7 @@ class RemoteSparqlOntology(Ontology):
         logging.debug("Fetching all syns...")
         # TODO: include_label in cache
         if self.all_synonyms_cache is None:
-            syntups = fetchall_syns(self.graph_name)
+            syntups = fetchall_syns(self.graph_name, ignore_cache=self.config.ignore_cache)
             syns = [Synonym(t[0],pred=t[1], val=t[2]) for t in syntups]
             for syn in syns:
                 self.add_synonym(syn)

--- a/ontobio/sparql/wikidata.py
+++ b/ontobio/sparql/wikidata.py
@@ -6,7 +6,10 @@ from SPARQLWrapper import SPARQLWrapper, JSON
 from prefixcommons.curie_util import contract_uri, expand_uri
 from functools import lru_cache
 import networkx
+
+from ontobio.config import get_config
 from cachier import cachier
+
 import datetime
 import logging
 
@@ -88,7 +91,7 @@ def ensure_prefixed(x, prefix):
                 
 def fetchall_xrefs(prefix):
     m = {}
-    pairs = fetchall_triples_xrefs(prefix)
+    pairs = fetchall_triples_xrefs(prefix, ignore_cache=get_config().ignore_cache)
     if len(pairs) == LIMIT:
         logging.error("Too many: {} {}".format(LIMIT, pairs[:10]))
         return None


### PR DESCRIPTION
The cachier caching in Ontobio causes some performance issues in some execution environments (e.g. NCATS Translator Workflow 2): it triggers deep recursion on creating cachier "Observer" threads and stack memory use, sometimes to all available operating system resources!

Disabling cachier in such instances, especially when wholesale retrieval of ontology for local use (once only) is done (as in Workflow 2 above) seems to resolve the issue.

Therefore an "ignore_cache" flag in ontobio/config.yaml (defaults to 'False') can be set to "True". This flag turns off all cachier use in the code base. 

In this fashion, clients of Ontobio can decide whether or not to use the cache for their use cases.