### PR TITLE
Remove cachier

### DIFF
--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -203,11 +203,6 @@ access. Currently an *eager* strategy is used, in which large blocks
 are fetched in advance, though in future *lazy* strategies are
 optionally employed.
 
-.. warning ::
-
-    We use the `cachier` library for caching. Currently there is no
-    API control over caching, and caches are by default store in
-    ``~/.cachier``. This may change in future.
 
 To be implemented
 -----------------

--- a/ontobio/assoc_factory.py
+++ b/ontobio/assoc_factory.py
@@ -10,8 +10,6 @@ import logging
 import os
 import subprocess
 import hashlib
-from cachier import cachier
-import datetime
 from ontobio.golr.golr_associations import bulk_fetch
 from ontobio.assocmodel import AssociationSet, AssociationSetMetadata
 from ontobio.io.hpoaparser import HpoaParser
@@ -20,7 +18,6 @@ from ontobio.io.gafparser import GafParser
 from ontobio.util.user_agent import get_user_agent
 from collections import defaultdict
 
-SHELF_LIFE = datetime.timedelta(days=3)
 
 class AssociationSetFactory():
     """
@@ -199,7 +196,6 @@ class AssociationSetFactory():
         return self.create_from_tuples(results, **args)
 
 
-@cachier(stale_after=SHELF_LIFE)
 def bulk_fetch_cached(**args):
         logging.info("Fetching assocs from store (will be cached)")
         return bulk_fetch(**args)

--- a/ontobio/ecomap.py
+++ b/ontobio/ecomap.py
@@ -1,14 +1,10 @@
 import requests
 from contextlib import closing
-from cachier import cachier
-import datetime
 import logging
 
 from ontobio.util.user_agent import get_user_agent
 
-SHELF_LIFE = datetime.timedelta(days=1)
 
-@cachier(stale_after=SHELF_LIFE)
 def get_ecomap_str(url):
     logging.info("Fetching ecomap from {}".format(url))
     with closing(requests.get(url, stream=False, headers={'User-Agent': get_user_agent(modules=[requests], caller_name=__name__)})) as resp:

--- a/ontobio/ontol_factory.py
+++ b/ontobio/ontol_factory.py
@@ -13,10 +13,7 @@ from ontobio.sparql.sparql_ontology import EagerRemoteSparqlOntology
 import os
 import subprocess
 import hashlib
-from cachier import cachier
-import datetime
 
-SHELF_LIFE = datetime.timedelta(days=3)
 
 # TODO
 default_ontology_handle = 'cache/ontologies/pato.json'
@@ -75,7 +72,6 @@ class OntologyFactory():
             return default_ontology
         return create_ontology(handle, **args)
 
-@cachier(stale_after=SHELF_LIFE)
 def create_ontology(handle=None, **args):
     ont = None
     logging.info("Determining strategy to load '{}' into memory...".format(handle))

--- a/ontobio/sim/api/owlsim2.py
+++ b/ontobio/sim/api/owlsim2.py
@@ -10,20 +10,17 @@ from ontobio.util.scigraph_util import get_nodes_from_ids, get_id_type_map, get_
 from typing import List, Optional, Dict, Tuple, Union
 from json.decoder import JSONDecodeError
 import logging
-from cachier import cachier
-import datetime
 import requests
 
 """
 Functions that directly access the owlsim rest API are kept
 outside the class to utilize cachier
+TODO: this will have to be revisited.
 """
 
 TIMEOUT = get_config().owlsim2.timeout
-SHELF_LIFE = datetime.timedelta(days=30)
 
 
-@cachier(SHELF_LIFE)
 def search_by_attribute_set(
         url: str,
         profile: Tuple[str],
@@ -49,7 +46,6 @@ def search_by_attribute_set(
     return requests.get(owlsim_url, params=params, timeout=TIMEOUT).json()
 
 
-@cachier(SHELF_LIFE)
 def compare_attribute_sets(
         url: str,
         profile_a: Tuple[str],
@@ -73,7 +69,6 @@ def compare_attribute_sets(
     return requests.get(owlsim_url, params=params, timeout=TIMEOUT).json()
 
 
-@cachier(SHELF_LIFE)
 def get_attribute_information_profile(
         url: str,
         profile: Optional[Tuple[str]]=None,
@@ -100,7 +95,6 @@ def get_attribute_information_profile(
     return requests.get(owlsim_url, params=params, timeout=TIMEOUT).json()
 
 
-@cachier(SHELF_LIFE)
 def get_owlsim_stats(url) -> Tuple[IcStatistic, Dict[str, IcStatistic]]:
     """
     :return Tuple[IcStatistic, Dict[str, IcStatistic]]

--- a/ontobio/sparql/sparql_ontol_utils.py
+++ b/ontobio/sparql/sparql_ontol_utils.py
@@ -15,15 +15,12 @@ from prefixcommons.curie_util import contract_uri, expand_uri
 from ontobio.vocabulary.relations import map_legacy_pred
 from functools import lru_cache
 import networkx
-from cachier import cachier
-import datetime
 import logging
 
 from enum import Enum
 
 SEPARATOR = "@|@"
 
-SHELF_LIFE = datetime.timedelta(days=7)
 
 # CACHE STRATEGY:
 # by default, the cache is NOT persistent. Only single threaded clients should
@@ -31,7 +28,6 @@ SHELF_LIFE = datetime.timedelta(days=7)
 # Note we are layering the in-memory cache over the persistent cache
 
 cache = lru_cache(maxsize=None)
-#cache = cachier(stale_after=SHELF_LIFE)
 
 
 SUBCLASS_OF = 'subClassOf'
@@ -87,7 +83,6 @@ def get_xref_graph(ont):
     return g
 
 
-@cachier(stale_after=SHELF_LIFE)
 def get_edges(ont):
     """
     Fetches all basic edges from a remote ontology
@@ -116,7 +111,6 @@ def search(ont, searchterm):
     bindings = run_sparql(query)
     return [(r['c']['value'],r['l']['value']) for r in bindings]
 
-@cachier(stale_after=SHELF_LIFE)
 def get_terms_in_subset(ont, subset):
     """
     Find all nodes in a subset.
@@ -227,7 +221,6 @@ def fetchall_svf(ont):
     bindings = run_sparql(query)
     return [(r['c']['value'], r['p']['value'], r['d']['value']) for r in bindings]
 
-@cachier(stale_after=SHELF_LIFE)
 def fetchall_labels(ont):
     """
     fetch all rdfs:label assertions for an ontology
@@ -244,7 +237,6 @@ def fetchall_labels(ont):
     rows = [(r['c']['value'], r['l']['value']) for r in bindings]
     return rows
 
-@cachier(stale_after=SHELF_LIFE)
 def fetchall_syns(ont):
     """
     fetch all synonyms for an ontology
@@ -262,7 +254,6 @@ def fetchall_syns(ont):
     rows = [(r['c']['value'], r['r']['value'], r['l']['value']) for r in bindings]
     return rows
 
-@cachier(stale_after=SHELF_LIFE)
 def fetchall_textdefs(ont):
     """
     fetch all text defs for an ontology
@@ -282,7 +273,6 @@ def fetchall_textdefs(ont):
     rows = [(r['c']['value'], r['d']['value']) for r in bindings]
     return rows
 
-@cachier(stale_after=SHELF_LIFE)
 def fetchall_xrefs(ont):
     """
     fetch all xrefs for an ontology
@@ -300,7 +290,6 @@ def fetchall_xrefs(ont):
     rows = [(r['c']['value'], r['x']['value']) for r in bindings]
     return rows
 
-@cachier(stale_after=SHELF_LIFE)
 def fetchall_obs(ont):
     """
     fetch all obsoletes for an ontology

--- a/ontobio/sparql/wikidata.py
+++ b/ontobio/sparql/wikidata.py
@@ -6,11 +6,8 @@ from SPARQLWrapper import SPARQLWrapper, JSON
 from prefixcommons.curie_util import contract_uri, expand_uri
 from functools import lru_cache
 import networkx
-from cachier import cachier
-import datetime
 import logging
 
-SHELF_LIFE = datetime.timedelta(days=7)
 
 # CACHE STRATEGY:
 # by default, the cache is NOT persistent. Only single threaded clients should
@@ -18,7 +15,6 @@ SHELF_LIFE = datetime.timedelta(days=7)
 # Note we are layering the in-memory cache over the persistent cache
 
 cache = lru_cache(maxsize=None)
-#cache = cachier(stale_after=SHELF_LIFE)
 
 LIMIT = 200000
 
@@ -100,7 +96,6 @@ def fetchall_xrefs(prefix):
         m[x].append(c)
     return m
 
-@cachier(stale_after=SHELF_LIFE)
 def fetchall_triples_xrefs(prefix):
     """
     fetch all xrefs for a prefix, e.g. CHEBI

--- a/ontobio/util/scigraph_util.py
+++ b/ontobio/util/scigraph_util.py
@@ -6,7 +6,6 @@ from json.decoder import JSONDecodeError
 from ontobio.ontol_factory import OntologyFactory
 from ontobio.model.similarity import Node, TypedNode
 import requests
-from cachier import cachier
 
 def namespace_to_taxon() -> Dict[str, Node]:
     """
@@ -164,7 +163,6 @@ def typed_node_from_id(id: str) -> TypedNode:
         taxon = get_taxon(id)
     )
 
-@cachier()
 def get_curie_map(url):
     """
     Get CURIE prefix map from SciGraph cypher/curies endpoint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# See: https://caremad.io/posts/2013/07/setup-vs-requirement/
-# --index-url https://pypi.python.org/simple/
-# -e .
 marshmallow==3.0.0b3
 jsobject>=0.0
 prefixcommons>=0.1.6
@@ -19,7 +16,7 @@ jsonpath_rw>=0.0
 pytest>=0.0
 pytest_logging>=0.0
 pydotplus>=0.0
-cachier==1.1.8
 plotly==2.0.7
 pyyaml
 yamldown>=0.1.7
+click

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setuptools.setup(
         'pysolr',
         'requests',
         'sparqlwrapper',
-        'cachier',
         'prefixcommons',
         'marshmallow==3.0.0b3',
         'scipy',


### PR DESCRIPTION
This PR removes the usage of Cachier from Ontobio.
An alternate caching mechanism will be introduced as a subsequent PR.

Refer to #358 for more on this discussion.