### PR TITLE
Use `fastobo` to load ontologies from OBO files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ cachier==1.1.8
 plotly==2.0.7
 pyyaml
 yamldown>=0.1.7
+fastobo~=0.3.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setuptools.setup(
         'pandas==0.24.2',
         'click==7.0',
         'yamldown',
-        'dataclasses'
+        'dataclasses',
+        'fastobo~=0.3.1',
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Hi !

This PR (finally) adds a native OBO parser using the [`fastobo`](https://pypi.org/project/fastobo/) package. This is very much WIP since there are no actual semantics for OBO to OBO Graphs translation, and the translation is in early development.

I added it in a way `fastobo` becomes a mandatory dependency, which is not optimal on platforms other than Linux and OSX x86-64 since it requires a Rust toolchain to be available on the target machine; I could make it optional as well if you think this is better.