### PR TITLE
Go site issue 970 example runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ foo:
 # only run local tests
 travis_test:
 	pytest tests/test_*local*.py tests/test_*parse*.py tests/test*writer*.py tests/test_qc.py \
-	       tests/test_rdfgen.py tests/test_phenosim_engine.py tests/unit/ tests/test_ontol.py
+	       tests/test_rdfgen.py tests/test_phenosim_engine.py tests/unit/ tests/test_ontol.py \
+		   tests/test_validation_rules.py
 
 cleandist:
 	rm dist/* || true

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -609,12 +609,13 @@ def rule(metadata_dir, out, ontology, gaferencer_file):
                 all_examples_valid = False
                 
         all_results += results
-        
-    try:
-        with open(out, "w") as outfile:
-            json.dump(rules.validation_report(all_results), outfile, indent=4)
-    except Exception as e:
-        raise click.ClickException("Could not write report to {}: ".format(out, e))
+    
+    if out:
+        try:
+            with open(out, "w") as outfile:
+                json.dump(rules.validation_report(all_results), outfile, indent=4)
+        except Exception as e:
+            raise click.ClickException("Could not write report to {}: ".format(out, e))
     
     if not all_examples_valid:
         raise click.ClickException("At least one rule example was not validated.")

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -601,7 +601,7 @@ def rule(metadata_dir, out, ontology, gaferencer_file):
         click.echo("Validating {} examples for {}".format(len(examples), rule_id.upper().replace("-", ":")))
         results = rules.validate_all_examples(examples, config=config)
         successes = sum(1 for r in results if r.success)
-        click.echo("\t- {}/{} success".format(successes, len(results)))
+        click.echo("\t* {}/{} success".format(successes, len(results)))
         for r in results:
             if not r.success:
                 click.echo("\tRule example failed: {}".format(r.reason))

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -28,6 +28,7 @@ from ontobio.io import gaference
 from ontobio.rdfgen import assoc_rdfgen
 from ontobio.validation import metadata
 from ontobio.validation import tools
+from ontobio.validation import rules
 
 from typing import Dict, Set
 
@@ -554,6 +555,69 @@ def paint(group, dataset, metadata, target, ontology):
     gpi_path = os.path.join(absolute_target, "groups", dataset, "{}.gpi".format(dataset))
     click.echo("Using GPI at {}".format(gpi_path))
     paint_gaf = produce_gaf("paint_{}".format(dataset), paint_src_gaf, ontology_graph, gpipath=gpi_path)
+
+
+@cli.command()
+@click.option("--metadata", "-m", "metadata_dir", type=click.Path(), required=True)
+@click.option("--out", type=click.Path(), required=False)
+@click.option("--ontology", type=click.Path(), required=True)
+@click.option("--gaferencer-file", "-I", type=click.Path(exists=True), default=None, required=False, help="Path to Gaferencer output to be used for inferences")
+def rule(metadata_dir, out, ontology, gaferencer_file):
+    absolute_metadata = os.path.abspath(metadata_dir)
+    absolute_out = os.path.abspath(out)
+    os.makedirs(os.path.dirname(absolute_out), exist_ok=True)
+    
+    click.echo("Loading ontology: {}...".format(ontology))
+    ontology_graph = OntologyFactory().create(ontology)
+    
+    goref_metadata = metadata.yamldown_lookup(os.path.join(absolute_metadata, "gorefs"))
+    gorule_metadata = metadata.yamldown_lookup(os.path.join(absolute_metadata, "rules"))
+    
+    click.echo("Found {} GO Rules".format(len(gorule_metadata.keys())))
+    
+    db_entities = metadata.database_entities(absolute_metadata)
+    group_ids = metadata.groups(absolute_metadata)
+    
+    gaferences = None
+    if gaferencer_file:
+        gaferences = gaference.load_gaferencer_inferences_from_file(gaferencer_file)
+    
+    config = assocparser.AssocParserConfig(
+        ontology=ontology_graph,
+        goref_metadata=goref_metadata,
+        entity_idspaces=db_entities,
+        group_idspace=group_ids,
+        annotation_inferences=gaferences
+    )
+    all_examples_valid = True
+    all_results = []
+    for rule_id, rule_meta in gorule_metadata.items():
+        examples = rules.RuleExample.example_from_json(rule_meta)
+        if len(examples) == 0:
+            # skip if there are no examples
+            continue
+        
+        click.echo("==============================================================================")
+        click.echo("Validating {} examples for {}".format(len(examples), rule_id.upper().replace("-", ":")))
+        results = rules.validate_all_examples(examples, config=config)
+        successes = sum(1 for r in results if r.success)
+        click.echo("\t- {}/{} success".format(successes, len(results)))
+        for r in results:
+            if not r.success:
+                click.echo("\tRule example failed: {}".format(r.reason))
+                click.echo("\tInput: >> `{}`".format(r.example.input))
+                all_examples_valid = False
+                
+        all_results += results
+        
+    try:
+        with open(out, "w") as outfile:
+            json.dump(rules.validation_report(all_results), outfile, indent=4)
+    except Exception as e:
+        raise click.ClickException("Could not write report to {}: ".format(out, e))
+    
+    if not all_examples_valid:
+        raise click.ClickException("At least one rule example was not validated.")
 
 
 if __name__ == "__main__":

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -109,6 +109,12 @@ class AssocParserConfig():
             self.include_relations = []
         if self.filter_out_evidence is None:
             self.filter_out_evidence = []
+            
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
 
 
 class Report():
@@ -398,6 +404,10 @@ class AssocParser(object):
         """
         raise NotImplementedError("AssocParser.skim not implemented")
 
+    def normalize_columns(self, number_of_columns, columns):
+        columns += [""] * (number_of_columns - len(columns))
+        return columns
+    
     def parse_line(self, line):
         raise NotImplementedError("AssocParser.parse_line not implemented")
 

--- a/ontobio/io/assocwriter.py
+++ b/ontobio/io/assocwriter.py
@@ -6,6 +6,8 @@ import re
 import datetime
 import json
 
+from typing import List
+
 from ontobio import ecomap
 
 external_taxon = re.compile("taxon:([0-9]+)")
@@ -33,11 +35,14 @@ class AssocWriter():
         return prefix, local_id
 
     def _write_row(self, vals):
-        line = "\t".join([_str(v) for v in vals])
+        line = tsv_as_string(vals)
         if self.file:
             self.file.write(line+"\n")
         else:
             print(line)
+            
+    def tsv_as_string(self, vals) -> str:
+        return "\t".join([_str(v) for v in vals])
 
     def _write(self, line):
         if self.file:
@@ -81,12 +86,19 @@ class AssocWriter():
             return "taxon:{num}".format(num=taxon_id)
 
         return taxon
+        
+    def as_tsv(self, assoc) -> List[str]:
+        """
+        Transform a single association to a string line.
+        """
+        pass
 
     def write_assoc(self, assoc):
         """
         Write a single association to a line in the output file
         """
-        pass  ## Implemented in subclasses
+        vals = self.as_tsv(assoc)
+        self._write_row(vals)
 
     def write(self, assocs, meta=None):
         """
@@ -112,7 +124,7 @@ class GpadWriter(AssocWriter):
         self._write("!gpa-version: 1.1\n")
         self.ecomap = ecomap.EcoMap()
 
-    def write_assoc(self, assoc):
+    def as_tsv(self, assoc):
         """
         Write a single association to a line in the output file
         """
@@ -154,7 +166,7 @@ class GpadWriter(AssocWriter):
                 self._extension_expression(assoc['object_extensions']),
                 annotation_properties]
 
-        self._write_row(vals)
+        return vals
 
 class GafWriter(AssocWriter):
     """
@@ -179,7 +191,7 @@ class GafWriter(AssocWriter):
 
         return full_taxon
 
-    def write_assoc(self, assoc):
+    def as_tsv(self, assoc):
         """
         Write a single association to a line in the output file
         """
@@ -241,4 +253,4 @@ class GafWriter(AssocWriter):
                 extension_expression,
                 gene_product_isoform]
 
-        self._write_row(vals)
+        return vals

--- a/ontobio/io/assocwriter.py
+++ b/ontobio/io/assocwriter.py
@@ -35,7 +35,7 @@ class AssocWriter():
         return prefix, local_id
 
     def _write_row(self, vals):
-        line = tsv_as_string(vals)
+        line = self.tsv_as_string(vals)
         if self.file:
             self.file.write(line+"\n")
         else:

--- a/ontobio/io/assocwriter.py
+++ b/ontobio/io/assocwriter.py
@@ -129,7 +129,7 @@ class GpadWriter(AssocWriter):
         Write a single association to a line in the output file
         """
         if assoc.get("header", False):
-            return
+            return []
 
         subj = assoc['subject']
 
@@ -200,10 +200,10 @@ class GafWriter(AssocWriter):
 
             # Skip incoming gaf-version headers, as we created the version above already
             if re.match("![\s]*gaf.?version", assoc["line"]):
-                return
+                return []
 
             self._write(assoc["line"] + "\n")
-            return
+            return []
 
         # print("Writing assoc {}".format(assoc))
         subj = assoc['subject']

--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -105,7 +105,7 @@ class GafParser(assocparser.AssocParser):
         # We treat everything as GAF2 by adding two blank columns.
         # TODO: check header metadata to see if columns corresponds to declared dataformat version
         if 17 > len(vals) >= 15:
-            vals += [""] * (17 - len(vals))
+            vals = self.normalize_columns(17, vals)
 
         if len(vals) > 17:
             # If we see more than 17 columns, we will just cut off the columns after column 17

--- a/ontobio/validation/rules.py
+++ b/ontobio/validation/rules.py
@@ -1,0 +1,163 @@
+import typing
+import enum
+import io
+import collections
+
+from dataclasses import dataclass
+from typing import List, TypeVar, Union, Generic, Optional
+
+from ontobio.validation import metadata
+from ontobio.io import assocparser
+from ontobio.io import gafparser
+from ontobio.io import assocwriter
+
+"""
+This module is for centralizing logic related to validating the example data in
+GO Rules. Optional data can be included in rules that show exmaples of failing,
+passing, or repair type rules for incoming data (either GAF, GPAD, or RDF). 
+
+This will first just support GAF for the first pass in all liklihood.
+
+Relavent schema:
+```
+"examples":
+  type: map
+    required: false
+    mapping:
+      "pass":
+        type: seq
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              "comment":
+                type: str
+                required: true
+              "format":
+                type: str
+                required: true
+                enum: ["rdf", "gaf", "gpad"]
+              "instance":
+                type: str
+                required: true
+      "fail":
+        type: seq
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              "comment":
+                type: str
+                required: true
+              "format":
+                type: str
+                required: true
+                enum: ["rdf", "gaf", "gpad"]
+              "instance":
+                type: str
+                required: true
+      "repair":
+        type: seq
+        required: false
+        sequence:
+          - type: map
+            mapping:
+              "comment":
+                type: str
+                required: true
+              "format":
+                type: str
+                required: true
+                enum: ["rdf", "gaf", "gpad"]
+              "input":
+                type: str
+                required: true
+              "output":
+                type: str
+                required: true
+```
+
+"""
+FormatType = enum.Enum("FormatType", ["RDF", "GAF", "GPAD"])
+ExampleType = enum.Enum("ExampleType", ["REPAIR", "FAIL", "PASS"])
+
+@dataclass
+class RuleExample:
+    rule_id: str
+    example_type: ExampleType
+    input: str
+    format: FormatType
+    expected: Union[str, bool]
+    
+@dataclass
+class ValidationResult:
+    example: RuleExample
+    actual: Union[str, bool]
+    success: bool
+    reason: str
+    
+Parsed = collections.namedtuple("Parsed", ["report", "output"])
+
+def normalize_tsv_row(size: int, tsv: str) -> str:
+    columns = tsv.split("\t")
+    if len(columns) < size:
+        columns += [""] * (size - len(columns))
+    elif len(columns) > size:
+        columns = columns[0:size]
+    
+    return "\t".join(columns)
+
+def validate_example(example: RuleExample) -> ValidationResult:
+    """
+    1. Create parser based on `format`
+    2. Run input into parser/validator
+    3. In parsed rule results, find the results for the rule given in the example
+    4. Decide on what the `output` is.
+    5. Validate output against the example `expected` to decide on `success`
+    6. Consolodate and return `ValidationResult`
+    """
+    parser = create_base_parser(example.format)
+    parsed = validate_input(example.input, parser)
+    success = example_success(example, parsed)
+    
+    actual = len(parsed.report) == 0 if example.example_type in [ExampleType.FAIL, ExampleType.PASS] else parsed.output
+    result = ValidationResult(example, actual, success, parsed.report[0]["message"])
+    
+    
+def create_base_parser(format: FormatType) -> Optional[assocparser.AssocParser]:
+    """
+    Make an unconfigured parser based on the format. Only GAF is supported currently.
+    """
+    parser = None
+    if format == FormatType.GAF:
+        parser = gafparser.GafParser(config=assocparser.AssocParserConfig())
+    else:
+        parser = None
+        
+    return parser
+
+
+def validate_input(input: str, parser: assocparser.AssocParser, config=None) -> Parsed:
+    if config:
+        parser.config = config
+    
+    out = []
+    writer = assocwriter.GafWriter(file=io.StringIO())
+    
+    assocs_gen = parser.association_generator(file=io.StringIO(input), skipheader=True)
+    for assoc in assocs_gen:
+        out.append(writer.tsv_as_string(writer.as_tsv(assoc)))
+        
+    rules_messages = parser.report.reporter.messages[example.rule_id]
+    return Parsed(report=rules_messages, output=out)
+
+
+def example_success(example: RuleExample, parsed_input: Parsed) -> bool:
+    success = False
+    if example.example_type == ExampleType.REPAIR:
+        success = parsed_input.output == expected.split("\n")
+    elif example.example_type in [ ExampleType.FAIL, ExampleType.PASS ]:
+        passed_rule = len(parsed_input.report) == 0
+        success = passed_rule == example.expected
+    
+    return success

--- a/tests/test_validation_rules.py
+++ b/tests/test_validation_rules.py
@@ -1,0 +1,83 @@
+from ontobio.validation import rules
+from ontobio.io import assocparser
+from ontobio.io import gafparser
+from ontobio import ontol_factory
+
+import json
+
+ontology = ontol_factory.OntologyFactory().create("tests/resources/goslim_generic.json")
+gaf_line = "PomBase\tSPBC11C11.03\tndc80\t\tGO:0000942\tPMID:11553715\tIDA\t\tC\tNMS complex subunit Ndc80\tndc10|tid3\tprotein\ttaxon:4896\t20150122\tPomBase"
+
+def test_create_base_parser():
+    parser = rules.create_base_parser(rules.FormatType.RDF)
+    assert parser == None
+    
+    parser = rules.create_base_parser(rules.FormatType.GAF)
+    assert type(parser) == gafparser.GafParser
+    assert parser.config == assocparser.AssocParserConfig()
+    
+def test_validate_input():
+    parser = rules.create_base_parser(rules.FormatType.GAF)
+    normal_gaf_line = rules.normalize_tsv_row(17, gaf_line)
+    example = rules.RuleExample("gorule-0000027", rules.ExampleType.FAIL, normal_gaf_line, rules.FormatType.GAF, False)
+    config = assocparser.AssocParserConfig(
+        ontology=ontology
+    )
+    
+    parsed = rules.validate_input(example, parser, config=config)
+    assert parsed.output == normal_gaf_line
+
+def test_example_success_with_fail_example():
+    # We expect this example to fail gorule 27, so expected is False
+    parser = rules.create_base_parser(rules.FormatType.GAF)
+    normalized = rules.normalize_tsv_row(17, gaf_line)
+    example = rules.RuleExample("gorule-0000027", rules.ExampleType.FAIL, normalized, rules.FormatType.GAF, False)
+    parsed = rules.validate_input(example, parser, config=assocparser.AssocParserConfig(ontology=ontology))
+
+    success = rules.example_success(example, parsed)
+    assert success == True
+    
+    # We falsely expect rule 1 to pass, so this test is expected to be False
+    parser = rules.create_base_parser(rules.FormatType.GAF)
+    normalized = rules.normalize_tsv_row(17, gaf_line)
+    example = rules.RuleExample("gorule-0000002", rules.ExampleType.FAIL, normalized, rules.FormatType.GAF, False)
+    parsed = rules.validate_input(example, parser, config=assocparser.AssocParserConfig(ontology=ontology))
+
+    success = rules.example_success(example, parsed)
+    assert success == False
+    
+def test_validate_example():
+    parser = rules.create_base_parser(rules.FormatType.GAF)
+    normalized = rules.normalize_tsv_row(17, gaf_line)
+    example = rules.RuleExample("gorule-0000027", rules.ExampleType.FAIL, normalized, rules.FormatType.GAF, False)
+    
+    expected = rules.ValidationResult(example, False, True, "Valid")
+    
+    config = assocparser.AssocParserConfig(ontology=ontology)
+    assert rules.validate_example(example, config=config) == expected
+    
+def test_format_parse():
+    
+    assert rules.format_from_string("rdf") == rules.FormatType.RDF
+    assert rules.format_from_string("gaf") == rules.FormatType.GAF
+    assert rules.format_from_string("gpad") == rules.FormatType.GPAD
+    assert rules.format_from_string("foo") == None
+    
+def test_example_json_converted():
+    
+    j = {
+        "id": "GORULE:0000027",
+        "examples": {
+            "fail": [
+                {
+                    "comment": "an example",
+                    "format": "gaf",
+                    "input": gaf_line
+                }
+            ]
+        }
+    }
+    
+    # normalized = rules.normalize_tsv_row(17, gaf_line)
+    example = rules.RuleExample("gorule-0000027", rules.ExampleType.FAIL, gaf_line, rules.FormatType.GAF, False)
+    assert rules.RuleExample.example_from_json(j) == [example]


### PR DESCRIPTION
This is for https://github.com/geneontology/go-site/issues/970

This creates a new command for the validate.py script: `rule`. You give it a path to the go-site metadata and an ontology and it will validate the `examples` given in go rules. We made the schema for this a while back. One can add exemplar data that is supposed to `PASS`, `FAIL`, or be `REPAIR`ed. `rule` will create a parser, parse the example data, and compare with what it was expected to get. An example is validated if it matches the state that the example was in. As in: if a gaf line is expected to fail a certain rule, and the parser successfully finds an error for that rule in the given example line, then that example is valid. 

Any invalid example will make the script exit with `1`. This should be used in ontobio travis to validate that the implementation of the rules are correct. 

Optionally a report JSON file will be written out. This could be run in the pipeline and be viewable as a product.