### PR TITLE
removing validation for gorule-000033 since it was deprecated

### DIFF
--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -604,20 +604,6 @@ class AssocParser(object):
 
         return sorted(valids)
 
-    def normalize_refs(self, references, line: SplitLine):
-        allowed_prefixes = {"PMID", "PMC", "doi", "GO_REF"}
-
-        found_bad_refs = []
-        okay_ref = []
-        for ref in references:
-            prefix = ref.split(":", maxsplit=1)[0]
-            if prefix not in allowed_prefixes:
-                # then we found a bad ref, so we'll record it
-                found_bad_refs.append(ref)
-
-        if found_bad_refs:
-            self.report.warning(line.line, Report.INVALID_IDSPACE, ", ".join(found_bad_refs), "References should only be from ID prefixes PMID, PMD, doi, or GO_REF", rule=33)
-
         # We are only reporting, so just pass it through
         return references
 

--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -236,8 +236,6 @@ class GafParser(assocparser.AssocParser):
             # Reporting occurs in above function call
             return assocparser.ParseResult(line, [], True)
 
-        references = self.normalize_refs(references, split_line)
-
         # With/From
         withfroms = self.validate_pipe_separated_ids(withfrom, split_line, empty_allowed=True, extra_delims=",")
         if withfroms == None:

--- a/tests/test_parse_ids.py
+++ b/tests/test_parse_ids.py
@@ -100,28 +100,3 @@ def test_doi_id():
     parser = gafparser.GafParser()
     valid = parser._validate_id("DOI:10.1007/BF00127499", assocparser.SplitLine("", [""]*17, "taxon:foo"))
     assert valid
-
-def test_normalize_refs_single_bad_ref():
-    parser = gafparser.GafParser()
-    ref = parser.normalize_refs(["FB:123"], assocparser.SplitLine("", [""]*17, "taxon:foo"))
-    assert ref == ["FB:123"]
-    assert len(parser.report.messages) == 1
-    assert parser.report.messages[0]["type"] == assocparser.Report.INVALID_IDSPACE
-
-def test_normalize_refs_many_bad_refs():
-    parser = gafparser.GafParser()
-    refs = parser.normalize_refs(["FB:123", "FB:234"], assocparser.SplitLine("", [""]*17, "taxon:foo"))
-    assert refs == ["FB:123", "FB:234"]
-    assert len(parser.report.messages) == 1
-    assert parser.report.messages[0]["type"] == assocparser.Report.INVALID_IDSPACE
-
-def test_normalize_refs_good_and_bad_refs():
-    parser = gafparser.GafParser()
-    refs = parser.normalize_refs(["FB:123", "PMID:234"], assocparser.SplitLine("", [""]*17, "taxon:foo"))
-    assert len(parser.report.messages) == 1
-    assert parser.report.messages[0]["type"] == assocparser.Report.INVALID_IDSPACE
-
-def test_normalize_refs_good():
-    parser = gafparser.GafParser()
-    refs = parser.normalize_refs(["PMID:123"], assocparser.SplitLine("", [""]*17, "taxon:foo"))
-    assert refs == ["PMID:123"]


### PR DESCRIPTION
See https://github.com/geneontology/go-site/pull/1197
And https://github.com/geneontology/go-site/issues/1082#issuecomment-556051891

gorule-0000033 will be deprecated, and so we will stop validating on that rule.