### PR TITLE
Support for querying for direct vs inferred associations, other fixes for ui

### DIFF
--- a/ontobio/sim/api/owlsim2.py
+++ b/ontobio/sim/api/owlsim2.py
@@ -47,7 +47,7 @@ def search_by_attribute_set(
         'limit': limit,
         'target': namespace_filter
     }
-    return requests.get(owlsim_url, params=params, timeout=TIMEOUT).json()
+    return requests.post(owlsim_url, data=params, timeout=TIMEOUT).json()
 
 
 @cache.memoize()
@@ -71,9 +71,7 @@ def compare_attribute_sets(
         'b': profile_b,
     }
 
-    print(requests.get(owlsim_url, params=params, timeout=TIMEOUT).json())
-
-    return requests.get(owlsim_url, params=params, timeout=TIMEOUT).json()
+    return requests.post(owlsim_url, data=params, timeout=TIMEOUT).json()
 
 
 @cache.memoize()
@@ -100,7 +98,7 @@ def get_attribute_information_profile(
         'a': profile,
         'r': categories
     }
-    return requests.get(owlsim_url, params=params, timeout=TIMEOUT).json()
+    return requests.post(owlsim_url, data=params, timeout=TIMEOUT).json()
 
 
 @cache.memoize()

--- a/ontobio/util/scigraph_util.py
+++ b/ontobio/util/scigraph_util.py
@@ -58,7 +58,7 @@ def get_scigraph_nodes(id_list)-> Iterator[Dict]:
     """
     scigraph = RemoteScigraphOntology('scigraph:data')
 
-    chunks = [id_list[i:i + 400] for i in range(0, len(list(id_list)), 400)]
+    chunks = [id_list[i:i + 100] for i in range(0, len(list(id_list)), 100)]
     for chunk in chunks:
         params = {
             'id': chunk,
@@ -95,6 +95,8 @@ def get_id_type_map(id_list: Iterable[str]) -> Dict[str, List[str]]:
     for node in get_scigraph_nodes(id_list):
         type_map[node['id']] = [typ.lower() for typ in node['meta']['types']
                                 if typ not in filter_out_types]
+        if not type_map[node['id']]:
+            type_map[node['id']] = ['Node']
 
     return type_map
 


### PR DESCRIPTION
I've made some small updates to support querying direct vs inferred associations by querying the subject/object_eq closures that have been newly added to the monarch solr.  This allows us to support direct queries on non clique leader identifiers, whereas before you were forced to use the subclass of|equivalence closure

Also some updates to support direct vs inferred taxa, although I may walk this back since including inferred taxa is desirable in the majority of cases, and we're only adding this because of some monarch hackiness - https://github.com/monarch-initiative/dipper/issues/860

Support for a generic fq param in biolink is possibly more ideal for these scenarios, but curious others thoughts on this.