### PR TITLE
adding some more logging in validate.py, removed verbose Expand log message

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -208,6 +208,7 @@ def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None, paint=False, 
         suppress_rule_reporting_tags=suppress_rule_reporting_tags,
         annotation_inferences=annotation_inferences
     )
+    logger.info("Producing {}".format(source_gaf))
     logger.info("AssocParserConfig used: {}".format(config))
     split_source = os.path.split(source_gaf)[0]
     validated_gaf_path = os.path.join(split_source, "{}_valid.gaf".format(dataset))
@@ -244,6 +245,7 @@ def produce_gaf(dataset, source_gaf, ontology_graph, gpipath=None, paint=False, 
         report_json.write(json.dumps(parser.report.to_report_json(), indent=4))
     
     logger.info("json {} written out".format(report_markdown_path))
+    logger.info("gorule-13 first 10 messages: {}".format(json.dumps(parser.report.to_report_json()["messages"]["gorule-0000013"][:10], indent=4)))
     logger.info("json current Stack:")
     traceback.print_stack()
 

--- a/ontobio/rdfgen/assoc_rdfgen.py
+++ b/ontobio/rdfgen/assoc_rdfgen.py
@@ -101,7 +101,7 @@ class RdfTransform(object):
         # allow either atoms or objects
         if isinstance(id, dict):
             return self.uri(id['id'])
-        logger.info("Expand: {}".format(id))
+        # logger.info("Expand: {}".format(id))
 
         id = self.bad_chars_regex.sub("_", id)
         uri = curie_util.expand_uri(id, cmaps=[prefix_context])


### PR DESCRIPTION
@valearna, @sierra-moxon, in assoc_rdfgen.py line 104 there is a log message for when we expand a CURIE into a URI.

Do you need this in your logs? I will be commenting this out in this PR as it is spamming our logs. Let me know if that messes you up!

Thanks,
Eric