### PR TITLE
Issue 427 rulesets

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -425,7 +425,7 @@ def merge_all_mixin_gaf_into_mod_gaf(valid_gaf_path, mixin_gaf_paths):
 
     return merged_path
 
-def mixin_a_dataset(valid_gaf, mixin_metadata_list, group_id, dataset, target, ontology, gpipath=None, base_download_url=None, replace_existing_files=True, rule_contexts=[]):
+def mixin_a_dataset(valid_gaf, mixin_metadata_list, group_id, dataset, target, ontology, gpipath=None, base_download_url=None, rule_metadata={}, replace_existing_files=True, rule_contexts=[]):
 
     end_gaf = valid_gaf
     mixin_gaf_paths = []
@@ -436,7 +436,7 @@ def mixin_a_dataset(valid_gaf, mixin_metadata_list, group_id, dataset, target, o
             mixin_dataset_metadata = mixin_dataset(mixin_metadata, dataset)
             mixin_dataset_id = mixin_dataset_metadata["dataset"]
             format = mixin_dataset_metadata["type"]
-            mixin_gaf = produce_gaf(mixin_dataset_id, mixin_src, ontology, gpipath=gpipath, paint=True, group=mixin_metadata["id"], format=format, rule_contexts=rule_contexts)[0]
+            mixin_gaf = produce_gaf(mixin_dataset_id, mixin_src, ontology, gpipath=gpipath, paint=True, group=mixin_metadata["id"], rule_metadata=rule_metadata, format=format, rule_contexts=rule_contexts)[0]
             mixin_gaf_paths.append(mixin_gaf)
 
     if mixin_gaf_paths:
@@ -469,7 +469,7 @@ def cli(ctx, verbose):
 @click.option("--suppress-rule-reporting-tag", "-S", multiple=True, help="Suppress markdown output messages from rules tagged with this tag")
 @click.option("--skip-existing-files", "-K", is_flag=True, default=False, help="When downloading files, if a file already exists it won't downloaded over")
 @click.option("--gaferencer-file", "-I", type=click.Path(exists=True), default=None, required=False, help="Path to Gaferencer output to be used for inferences")
-@click.option("--rule-context", "T", "rule_contexts", default=[], multiple=True, required=False, help="Context that the rules should be run under. This adds rules that have a tag that matches `context-[value]`")
+@click.option("--rule-context", "-T", "rule_contexts", default=[], multiple=True, required=False, help="Context that the rules should be run under. This adds rules that have a tag that matches `context-[value]`")
 def produce(ctx, group, metadata_dir, gpad, ttl, target, ontology, exclude, base_download_url, suppress_rule_reporting_tag, skip_existing_files, gaferencer_file, rule_contexts):
 
     logger.info("Logging is verbose")
@@ -522,12 +522,12 @@ def produce(ctx, group, metadata_dir, gpad, ttl, target, ontology, exclude, base
             group_idspace=group_ids,
             suppress_rule_reporting_tags=suppress_rule_reporting_tag,
             annotation_inferences=gaferences,
-            rule_context=rule_contexts
+            rule_contexts=rule_contexts
             )[0]
 
         gpi = produce_gpi(dataset, absolute_target, valid_gaf, ontology_graph)
 
-        end_gaf = mixin_a_dataset(valid_gaf, mixin_metadata_list, group_metadata["id"], dataset, absolute_target, ontology_graph, gpipath=gpi, base_download_url=base_download_url, replace_existing_files=not skip_existing_files)
+        end_gaf = mixin_a_dataset(valid_gaf, mixin_metadata_list, group_metadata["id"], dataset, absolute_target, ontology_graph, gpipath=gpi, base_download_url=base_download_url, rule_metadata=rule_metadata, replace_existing_files=not skip_existing_files)
         make_products(dataset, absolute_target, end_gaf, products, ontology_graph)
 
 

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -76,7 +76,8 @@ class AssocParserConfig():
                  goref_metadata=None,
                  dbxrefs=None,
                  suppress_rule_reporting_tags=[],
-                 annotation_inferences=None):
+                 annotation_inferences=None,
+                 rule_contexts=[]):
 
         self.remove_double_prefixes=remove_double_prefixes
         self.ontology=ontology
@@ -97,6 +98,7 @@ class AssocParserConfig():
         self.annotation_inferences = annotation_inferences
         self.entity_idspaces = entity_idspaces
         self.group_idspace = None if group_idspace is None else set(group_idspace)
+        self.rule_contexts = rule_contexts
         # This is a dictionary from ruleid: `gorule-0000001` to title strings
         if self.exclude_relations is None:
             self.exclude_relations = []
@@ -110,7 +112,7 @@ class AssocParserConfig():
             return self.__dict__ == other.__dict__
         else:
             return False
-            
+
     def __str__(self):
         s = "AssocParserConfig("
         attribute_values = ["{att}={val}".format(att=att, val=dict([(k, v) for k, v in value.items()][:8]) if isinstance(value, dict) else value) for att, value in vars(self).items()]

--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -72,7 +72,7 @@ class AssocParserConfig():
                  filtered_evidence_file=None,
                  gpi_authority_path=None,
                  paint=False,
-                 rule_metadata=None,
+                 rule_metadata=dict(),
                  goref_metadata=None,
                  dbxrefs=None,
                  suppress_rule_reporting_tags=[],

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -531,6 +531,20 @@ GoRules = enum.Enum("GoRules", {
     "GoRule13": GoRule13()
 })
 
+def _construct_rules_run(rule_metadata, rule_contexts) -> List[GoRule]:
+    rule_tags_to_match = set([ "context-{}".format(c) for c in rule_contexts ]) # context-import, context-foo
+    # additional rules from normal are context-* rules where any context-* matches a tag in rule_tags_to_match
+    additional_contextual_rules = [ r["id"] for r in rule_metadata if any(set(filter(lambda t: t.startswith("context-"), r.get("tags", []))).intersection(rule_tags_to_match)) ]
+    standard_rule_set = [ r["id"] for r in rule_metadata if r.get("tags", []) == [] or any(filter(lambda t: not t.startswith("context-"), r.get("tags", []))) ]
+
+    return standard_rule_set + additional_contextual_rules
+
+def _additional_context_rules(rule_metadata, rule_contexts):
+    rule_tags_to_match = set([ "context-{}".format(c) for c in rule_contexts ]) # context-import, context-foo
+    additional_contextual_rules = [ r["id"] for r in rule_metadata if any(set(filter(lambda t: t.startswith("context-"), r.get("tags", []))).intersection(rule_tags_to_match)) ]
+    return additional_contextual_rules
+
+
 GoRulesResults = collections.namedtuple("GoRulesResults", ["all_results", "annotation"])
 def test_go_rules(annotation: association.GoAssociation, config: assocparser.AssocParserConfig, group=None) -> GoRulesResults:
     all_results = {}

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -4,6 +4,8 @@ import collections
 import datetime
 import copy
 
+from dataclasses import dataclass
+
 from typing import List, Dict, Any, Tuple, Union
 from ontobio import ontol
 from ontobio import ecomap
@@ -49,10 +51,11 @@ def repair_result(repair_state: RepairState, fail_mode: FailMode) -> ResultType:
 
 class GoRule(object):
 
-    def __init__(self, id, title, fail_mode: FailMode):
+    def __init__(self, id, title, fail_mode: FailMode, tags=[]):
         self.id = id
         self.title = title
         self.fail_mode = fail_mode
+        self.run_context_tags = set(tags)
 
     def _list_terms(self, pipe_separated):
         terms = pipe_separated.split("|")
@@ -62,18 +65,28 @@ class GoRule(object):
     def _result(self, passes: bool) -> TestResult:
         return TestResult(result(passes, self.fail_mode), self.title, passes)
 
+    def _is_run_from_context(self, config: assocparser.AssocParserConfig) -> bool:
+        rule_tags_to_match = set([ "context-{}".format(c) for c in config.rule_contexts ])
+        # If there is no context, then run
+        # Or, if any run_context_tags is in rule_tags_to_match, then run
+        return self.run_context_tags is set() or any(self.run_context_tags & rule_tags_to_match)
+
     def run_test(self, annotation: association.GoAssociation, config: assocparser.AssocParserConfig, group=None) -> TestResult:
-        result = self.test(annotation, config, group=group)
+        result = TestResult(ResultType.PASS, "", True)  # Initial
+        if self._is_run_from_context(config):
+            result = self.test(annotation, config, group=group)
+
         result.result = annotation
         return result
+
 
     def test(self, annotation: association.GoAssociation, config: assocparser.AssocParserConfig, group=None) -> TestResult:
         pass
 
 class RepairRule(GoRule):
 
-    def __init__(self, id, title, fail_mode):
-        super().__init__(id, title, fail_mode)
+    def __init__(self, id, title, fail_mode, tags=[]):
+        super().__init__(id, title, fail_mode, tags)
 
     def message(self, state: RepairState) -> str:
         message = ""
@@ -530,15 +543,6 @@ GoRules = enum.Enum("GoRules", {
     # GoRule13 at the bottom in order to make all other rules clean up an annotation before reaching 13
     "GoRule13": GoRule13()
 })
-
-def _construct_rules_run(rule_metadata, rule_contexts) -> List[GoRule]:
-    rule_tags_to_match = set([ "context-{}".format(c) for c in rule_contexts ]) # context-import, context-foo
-    # additional rules from normal are context-* rules where any context-* matches a tag in rule_tags_to_match
-    additional_contextual_rules = [ r["id"] for r in rule_metadata if any(set(filter(lambda t: t.startswith("context-"), r.get("tags", []))).intersection(rule_tags_to_match)) ]
-    standard_rule_set = [ r["id"] for r in rule_metadata if r.get("tags", []) == [] or any(filter(lambda t: not t.startswith("context-"), r.get("tags", []))) ]
-
-    return standard_rule_set + additional_contextual_rules
-
 
 
 GoRulesResults = collections.namedtuple("GoRulesResults", ["all_results", "annotation"])

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -539,10 +539,6 @@ def _construct_rules_run(rule_metadata, rule_contexts) -> List[GoRule]:
 
     return standard_rule_set + additional_contextual_rules
 
-def _additional_context_rules(rule_metadata, rule_contexts):
-    rule_tags_to_match = set([ "context-{}".format(c) for c in rule_contexts ]) # context-import, context-foo
-    additional_contextual_rules = [ r["id"] for r in rule_metadata if any(set(filter(lambda t: t.startswith("context-"), r.get("tags", []))).intersection(rule_tags_to_match)) ]
-    return additional_contextual_rules
 
 
 GoRulesResults = collections.namedtuple("GoRulesResults", ["all_results", "annotation"])

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,5 +1,6 @@
 import pytest
 import datetime
+import json
 
 from ontobio.io import qc
 from ontobio.io import gaference
@@ -564,6 +565,23 @@ def test_all_rules():
     assert len(test_results.keys()) == 20
     assert test_results[qc.GoRules.GoRule26.value].result_type == qc.ResultType.PASS
     assert test_results[qc.GoRules.GoRule29.value].result_type == qc.ResultType.PASS
+
+def test_construct_rules_run():
+    with open("tests/resources/rules_metadata.json") as metadata_file:
+        rules_metadata = json.load(metadata_file)
+
+    # Test with an "import" context
+    constructed = set(qc._construct_rules_run(rules_metadata.values(), ["import"]))
+    assert constructed == set(['GORULE:0000051', 'GORULE:0000053', 'GORULE:0000054', 'GORULE:0000055', 'GORULE:0000056', 'GORULE:0000057', 'GORULE:0000058'])
+
+    # Test with no context
+    constructed = set(qc._construct_rules_run(rules_metadata.values(), []))
+    assert constructed == set(['GORULE:0000051', 'GORULE:0000053', 'GORULE:0000054', 'GORULE:0000055', 'GORULE:0000056'])
+
+    # Fake context
+    constructed = set(qc._construct_rules_run(rules_metadata.values(), ["blah"]))
+    assert constructed == set(['GORULE:0000051', 'GORULE:0000053', 'GORULE:0000054', 'GORULE:0000055', 'GORULE:0000056'])
+
 
 
 if __name__ == "__main__":

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -566,23 +566,6 @@ def test_all_rules():
     assert test_results[qc.GoRules.GoRule26.value].result_type == qc.ResultType.PASS
     assert test_results[qc.GoRules.GoRule29.value].result_type == qc.ResultType.PASS
 
-def test_construct_rules_run():
-    with open("tests/resources/rules_metadata.json") as metadata_file:
-        rules_metadata = json.load(metadata_file)
-
-    # Test with an "import" context
-    constructed = set(qc._construct_rules_run(rules_metadata.values(), ["import"]))
-    assert constructed == set(['GORULE:0000051', 'GORULE:0000053', 'GORULE:0000054', 'GORULE:0000055', 'GORULE:0000056', 'GORULE:0000057', 'GORULE:0000058'])
-
-    # Test with no context
-    constructed = set(qc._construct_rules_run(rules_metadata.values(), []))
-    assert constructed == set(['GORULE:0000051', 'GORULE:0000053', 'GORULE:0000054', 'GORULE:0000055', 'GORULE:0000056'])
-
-    # Fake context
-    constructed = set(qc._construct_rules_run(rules_metadata.values(), ["blah"]))
-    assert constructed == set(['GORULE:0000051', 'GORULE:0000053', 'GORULE:0000054', 'GORULE:0000055', 'GORULE:0000056'])
-
-
 
 if __name__ == "__main__":
     pytest.main(args=["tests/test_qc.py"])


### PR DESCRIPTION
This adds a command line option `--rule-context/-T` to ontobio validate that takes a "rule context".

In the GO Rules, we allow a _tag_ of `context-import` to indicate that the rule should be run during an import pipeline run, but not in an ordinary run.

To specify that a the validation should run the import rule set, the option `-T import` will tell ontobio to run any rule that has the `context-import` tag. When this is not set, rules that have the tag will be skipped. However, they will still appear in the reports as having no errors. 