### PR TITLE
report error if qualifiers are wrong in any way

### DIFF
--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -347,6 +347,7 @@ class GafParser(assocparser.AssocParser):
 ecomap = EcoMap()
 ecomap.mappings()
 relation_tuple = re.compile(r'(.+)\((.+)\)')
+allowed_qualifiers = set(["contributes_to", "colocalizes_with"])
 def to_association(gaf_line: List[str], report=None, group="unknown", dataset="unknown") -> assocparser.ParseResult:
     report = Report(group=group, dataset=dataset) if report is None else report
     source_line = "\t".join(gaf_line)
@@ -399,11 +400,7 @@ def to_association(gaf_line: List[str], report=None, group="unknown", dataset="u
     negated, relation, qualifiers = assocparser._parse_qualifier(gaf_line[3], aspect)
 
     # For allowed, see http://geneontology.org/docs/go-annotations/#annotation-qualifiers
-    allowed_qualifiers = ["contributes_to", "colocalizes_with"]
     for q in qualifiers:
-        if " " in q:
-            report.warning(source_line, Report.INVALID_ID, q, "Qualifiers must only use underscores instead of spaces, but was repaired", taxon=gaf_line[TAXON_INDEX], rule=1)
-            q.replace(" ", "_")
 
         if q not in allowed_qualifiers:
             report.error(source_line, Report.INVALID_QUALIFIER, q, "Qualifiers must be `contributes_to`, `colocalizes_with`, or `NOT`", taxon=gaf_line[TAXON_INDEX], rule=1)

--- a/tests/resources/test-qualifiers.gaf
+++ b/tests/resources/test-qualifiers.gaf
@@ -1,9 +1,10 @@
 !gaf-version: 2.1
 !Project_name: Fake
 MGI	MGI:88276	Ctnnb1	acts_upstream_of	GO:1904948	MGI:MGI:3836885|PMID:19122665	IMP		P	catenin (cadherin associated protein), beta 1	beta catenin|beta-catenin|Catnb	protein	taxon:10090	20160209	ParkinsonsUK-UCL	occurs_in(EMAPA:16975)
-PomBase	SPCC736.14	dis1	colocalizes_with	GO:0035371	PAINT_REF:12609	IMP	PANTHER:PTN000288762	C	TOG/XMAP14 microtubule-associated protein Dis1	UniProtKB:Q09933|PTN000288823	protein	NCBITaxon:4896	20161005	GO_Central
+MGI	SPCC736.14	dis1	colocalizes_with	GO:0035371	PAINT_REF:12609	IMP	PANTHER:PTN000288762	C	TOG/XMAP14 microtubule-associated protein Dis1	UniProtKB:Q09933|PTN000288823	protein	NCBITaxon:4896	20161005	GO_Central
 PomBase	SPAC1296.02	cox4	contributes_to	GO:0004129	PAINT_REF:10122	ISO	PANTHER:PTN000012880	F	cytochrome c oxidase subunit IV (predicted)	UniProtKB:P79010|PTN000012940	protein	NCBITaxon:4896	20160819	GO_Central
 PomBase	SPAC25B8.17	ypf1	involved_in	GO:1990578	GO_REF:0000024	ISO	SGD:S000001583	C	intramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)	ppp81	protein	taxon:4896	20150305	PomBase
 PomBase	SPBC1711.04	mtd1	NOT	GO:0004488	PAINT_REF:10025	ISO	PANTHER:PTN000002254	F	methylenetetrahydrofolate reductase Mtd1 (predicted)	UniProtKB:Q9P786|PTN000002263	protein	NCBITaxon:4896	20120921	GO_Central
 PomBase	SPBC1711.04	mtd1	NOT	GO:0004477	PAINT_REF:10025	IMP	PANTHER:PTN000002254	F	methylenetetrahydrofolate reductase Mtd1 (predicted)	UniProtKB:Q9P786|PTN000002263	protein	NCBITaxon:4896	20120921	GO_Central
 PomBase	SPBC1703.04	mlh1	NOT	GO:0000795	PAINT_REF:10073	IC	GO:1234567|PANTHER:PTN000008207	C	MutL family protein Mlh1 (predicted)	UniProtKB:Q9P7W6|PTN000008215	protein	NCBITaxon:4896	20120921	GO_Central
+PomBase	SPCC736.14	dis1	colocalizes with	GO:0035371	PAINT_REF:12609	IMP	PANTHER:PTN000288762	C	TOG/XMAP14 microtubule-associated protein Dis1	UniProtKB:Q09933|PTN000288823	protein	NCBITaxon:4896	20161005	GO_Central

--- a/tests/test_gafparser.py
+++ b/tests/test_gafparser.py
@@ -192,7 +192,7 @@ def test_qualifiers_gaf():
     assert len([a for a in assocs if a['relation']['id'] == 'contributes_to']) == 1
 
     # For the space in `colocalizes with`
-    assert len(list(filter(lambda e: e["level"] == "WARNING", p.report.to_report_json()["messages"]["gorule-0000001"]))) == 1
+    assert len(list(filter(lambda e: e["obj"] == "colocalizes with", p.report.to_report_json()["messages"]["gorule-0000001"]))) == 1
     assert len(list(filter(lambda e: e["obj"] == "involved_in", p.report.to_report_json()["messages"]["gorule-0000001"]))) == 1
 
 

--- a/tests/test_gafparser.py
+++ b/tests/test_gafparser.py
@@ -39,7 +39,7 @@ def test_skim_gaf_qualifiers():
         (s, sn, o) = r
         assert o.startswith('GO:')
         assert s.startswith('MGI:') or s.startswith('PomBase')
-    assert len(results) == 4  # ensure NOTs are skipped
+    assert len(results) == 5  # ensure NOTs are skipped
 
     p.config.exclude_relations = ['contributes_to', 'colocalizes_with']
     results = p.skim(open(QGAF, "r"))
@@ -47,7 +47,7 @@ def test_skim_gaf_qualifiers():
         (s, sn, o) = r
         assert o.startswith('GO:')
         assert s.startswith('MGI:') or s.startswith('PomBase')
-    assert len(results) == 2 # ensure NOTs and excludes relations skipped
+    assert len(results) == 3 # ensure NOTs and excludes relations skipped
 
 def test_one_line():
     p = GafParser(config=assocparser.AssocParserConfig(
@@ -179,17 +179,21 @@ def test_validate_go_idspaces():
 #POMBASE_GPAD = "tests/resources/truncated-pombase.gpad"
 
 def test_qualifiers_gaf():
-    ont = OntologyFactory().create(ONT)
+    # ont = OntologyFactory().create(ONT)
 
     p = GafParser()
-    p.config.ontology = ont
+    # p.config.ontology = ont
     assocs = p.parse(open(QGAF, "r"), skipheader=True)
     neg_assocs = [a for a in assocs if a['negated'] == True]
     assert len(neg_assocs) == 3
     for a in assocs:
         print('REL: {}'.format(a['relation']))
-    assert len([a for a in assocs if a['relation']['id'] == 'involved_in']) == 1
+
     assert len([a for a in assocs if a['relation']['id'] == 'contributes_to']) == 1
+
+    # For the space in `colocalizes with`
+    assert len(list(filter(lambda e: e["level"] == "WARNING", p.report.to_report_json()["messages"]["gorule-0000001"]))) == 1
+    assert len(list(filter(lambda e: e["obj"] == "involved_in", p.report.to_report_json()["messages"]["gorule-0000001"]))) == 1
 
 
 def parse_with2(f, p):


### PR DESCRIPTION
…, filter wrong qualifiers

For https://github.com/geneontology/helpdesk/issues/252

This fixes a bug where malformed qualifiers and wrong qualifiers not allowed were all allowed through the parser with no issue.

Qualifiers with spaces will be repaired with underscores.