### PR TITLE
adding option to give ontobio-parse-assocs a gaf inferences file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ foo:
 # only run local tests
 travis_test:
 	pytest tests/test_*local*.py tests/test_*parse*.py tests/test*writer*.py tests/test_qc.py \
-	       tests/test_rdfgen.py tests/test_phenosim_engine.py tests/unit/ tests/test_ontol.py \
-		   tests/test_validation_rules.py
+	       tests/test_rdfgen.py tests/test_phenosim_engine.py tests/test_ontol.py \
+		   tests/test_validation_rules.py tests/unit/test_annotation_scorer.py tests/unit/test_golr_search_query.py tests/unit/test_owlsim2_api.py
 
 cleandist:
 	rm dist/* || true


### PR DESCRIPTION
To run with gaferences, the relavent part is the `-I`.
```
ontobio-parse-assocs.py -f target/groups/mgi/mgi.gaf -F gaf -o target/groups/mgi/mgi.aug.gaf -I mgi.gaferences.json --report-md target/groups/mgi/mgi.report.md --report-json target/groups/mgi/mgi.report.json validate
```