### PR TITLE
Issue 477 curie leaking

### DIFF
--- a/bin/ontobio-parse-assocs.py
+++ b/bin/ontobio-parse-assocs.py
@@ -72,8 +72,6 @@ def main():
                         help='Increase output verbosity')
     parser.add_argument("--allow_paint", required=False, action="store_const", const=True,
                         help="Allow IBAs in parser")
-    parser.add_argument("-g", "--gpi", type=str, required=False, default=None,
-                        help="GPI file")
 
 
     subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
@@ -135,10 +133,8 @@ def main():
         filter_out_evidence=args.filter_out,
         filtered_evidence_file=filtered_evidence_file,
         annotation_inferences=gaferences,
-        paint=args.allow_paint,
-        gpi_authority_path=args.gpi
+        paint=args.allow_paint
     )
-    print(config.gpi_authority_path)
     p = None
     fmt = None
     if args.format is None:

--- a/bin/ontobio-parse-assocs.py
+++ b/bin/ontobio-parse-assocs.py
@@ -72,6 +72,8 @@ def main():
                         help='Increase output verbosity')
     parser.add_argument("--allow_paint", required=False, action="store_const", const=True,
                         help="Allow IBAs in parser")
+    parser.add_argument("-g", "--gpi", type=str, required=False, default=None,
+                        help="GPI file")
 
 
     subparsers = parser.add_subparsers(dest='subcommand', help='sub-command help')
@@ -133,8 +135,10 @@ def main():
         filter_out_evidence=args.filter_out,
         filtered_evidence_file=filtered_evidence_file,
         annotation_inferences=gaferences,
-        paint=args.allow_paint
+        paint=args.allow_paint,
+        gpi_authority_path=args.gpi
     )
+    print(config.gpi_authority_path)
     p = None
     fmt = None
     if args.format is None:
@@ -144,16 +148,14 @@ def main():
 
     # TODO: use a factory
     if fmt == 'gaf':
-        p = GafParser(dataset=args.file)
+        p = GafParser(config=config, dataset=args.file)
     elif fmt == 'gpad':
-        p = GpadParser()
+        p = GpadParser(config=config)
     elif fmt == 'hpoa':
-        p = HpoaParser()
+        p = HpoaParser(config=config)
     elif fmt == "gpi":
         p = entityparser.GpiParser()
         func = validate_entity
-
-    p.config = config
 
     outfh = None
     if args.outfile is not None:

--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -41,7 +41,7 @@ class GpadParser(assocparser.AssocParser):
         """
         self.config = config
         self.report = assocparser.Report(config=self.config, group="unknown", dataset="unknown")
-        self.gpi = dict()
+        self.gpi = None
         if self.config.gpi_authority_path is not None:
             print("Loading GPI...")
             self.gpi = dict()

--- a/ontobio/io/hpoaparser.py
+++ b/ontobio/io/hpoaparser.py
@@ -11,7 +11,7 @@ class HpoaParser(AssocParser):
     Note that there are similarities with Gaf format, so we inherit from GafParser, and override
     """
 
-    def __init__(self,config=assocparser.AssocParserConfig()):
+    def __init__(self, config=assocparser.AssocParserConfig()):
         """
         Arguments:
         ---------


### PR DESCRIPTION
Curies were being leaked from an unstringed taxon Curie object into the report. So when we went to turn the report into JSON it broke since the Curie object doesn't know how to be a JSON object. Now Curies are converted into strings before submitted to the report.