### PR TITLE
gpad parser now takes taxon element out of the list instead of passing on the entire list

### DIFF
--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -302,7 +302,7 @@ def from_1_2(gpad_line: List[str], report=None, group="unknown", dataset="unknow
             report.error(source_line, Report.INVALID_TAXON, taxon_result.original, taxon_result.message, taxon=taxon_result.original, rule=1)
             return assocparser.ParseResult(source_line, [], True, report=report)
         else:
-            interacting_taxon = taxon_result.parsed
+            interacting_taxon = taxon_result.parsed[0]
 
     conjunctions = []
     if gpad_line[10]:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
         'marshmallow==3.0.0b11',
         'scipy',
         'pandas==1.0.5',
-        'click==7.0',
+        'click',
         'yamldown',
         'dataclasses',
         'diskcache>=4.0.0',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
 
     # Dependencies
     install_requires=[
-        'networkx==2.2',
+        'networkx',
         'jsobject',
         'pyyaml',
         'pysolr',
@@ -53,7 +53,7 @@ setuptools.setup(
         'prefixcommons',
         'marshmallow==3.0.0b11',
         'scipy',
-        'pandas==1.0.5',
+        'pandas',
         'click',
         'yamldown',
         'dataclasses',

--- a/tests/test_gpad_parser.py
+++ b/tests/test_gpad_parser.py
@@ -40,6 +40,25 @@ def test_parse_1_2():
     assert len([m for m in result.report.messages if m["level"] == "ERROR"]) == 0
     assert len(result.associations) == 1
 
+def test_parse_interacting_taxon():
+    report = assocparser.Report(group="unknown", dataset="unknown")
+    vals = [
+        "MGI",
+        "MGI:1918911",
+        "enables",
+        "GO:0003674",
+        "MGI:MGI:2156816|GO_REF:0000015",
+        "ECO:0000307",
+        "",
+        "taxon:5678",
+        "20100209",
+        "MGI",
+        "",
+        "creation-date=2020-09-17|modification-date=2020-09-17|contributor-id=http://orcid.org/0000-0003-2689-5511"
+    ]
+    result = to_association(list(vals), report=report, version="1.2")
+    assert result.associations[0].interacting_taxon == Curie(namespace="NCBITaxon", identity="5678")
+
 
 def test_parse_2_0():
     version = "2.0"


### PR DESCRIPTION
Fixes issue #489