### PR TITLE
Pass normalized date to GoAssoc for #493

### DIFF
--- a/ontobio/io/assocparser.py
+++ b/ontobio/io/assocparser.py
@@ -838,18 +838,19 @@ def _normalize_gaf_date(date, report, taxon, line):
 
     # We check int(date)
     if len(date) == 8 and date.isdigit():
-        d = datetime.datetime(int(date[0:4]), int(date[4:6]), int(date[6:8]), 0, 0, 0, 0)
+        d = association.Date(date[0:4], date[4:6], date[6:8], "")
     else:
         report.warning(line, Report.INVALID_DATE, date, "GORULE:0000001: Date field must be YYYYMMDD, got: {}".format(date),
             taxon=taxon, rule=1)
         try:
             d = dateutil.parser.parse(date)
+            d = association.Date(str(d.year), str(d.month), str(d.day), "")
         except:
             report.error(line, Report.INVALID_DATE, date, "GORULE:0000001: Could not parse date '{}' at all".format(date),
                 taxon=taxon, rule=1)
             return None
 
-    return d.strftime("%Y%m%d")
+    return d
 
 ## we generate both qualifier and relation field
 ## Returns: (negated, relation, other_qualifiers)

--- a/ontobio/io/gafparser.py
+++ b/ontobio/io/gafparser.py
@@ -18,6 +18,7 @@ from ontobio.model import collections
 from ontobio.ecomap import EcoMap
 from ontobio.rdfgen import relations
 
+import dateutil.parser
 import functools
 
 import click
@@ -301,7 +302,7 @@ def to_association(gaf_line: List[str], report=None, group="unknown", dataset="u
 
     taxon = parsed_taxons_result.parsed[0]
 
-    date = assocparser._normalize_gaf_date(gaf_line[13], report, str(taxon), source_line)
+    date = assocparser.parse_date(gaf_line[13], report, source_line)
     if date is None:
         return assocparser.ParseResult(source_line, [], True, report=report)
 

--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -331,7 +331,7 @@ def from_1_2(gpad_line: List[str], report=None, group="unknown", dataset="unknow
         subject_extensions=[],
         object_extensions=conjunctions,
         provided_by=gpad_line[9],
-        date=gpad_line[8],
+        date=date,
         properties={ prop[0]: prop[1] for prop in properties_list if prop })
 
     return assocparser.ParseResult(source_line, [a], False, report=report)

--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -291,7 +291,7 @@ def from_1_2(gpad_line: List[str], report=None, group="unknown", dataset="unknow
 
     qualifiers = [association.Curie.from_str(curie_util.contract_uri(q)[0]) for q in looked_up_qualifiers]
 
-    date = assocparser._normalize_gaf_date(gpad_line[8], report, "", source_line)
+    date = assocparser.parse_date(gpad_line[8], report, source_line)
     if date is None:
         return assocparser.ParseResult(source_line, [], True, report=report)
 
@@ -424,12 +424,9 @@ def from_2_0(gpad_line: List[str], report=None, group="unknown", dataset="unknow
             report.error(source_line, Report.INVALID_SYMBOL, gpad_line[7], "Problem parsing Interacting Taxon", taxon=taxon, rule=1)
             return assocparser.ParseResult(source_line, [], True, report=report)
 
-    date_str = gpad_line[DATE_INDEX]
-    if date_str is None or date_str == "":
-        report.warning(source_line, Report.INVALID_DATE, date_str, "GORULE:0000001: empty",
-                       taxon=taxon, rule=1)
+    date = assocparser.parse_iso_date(gpad_line[DATE_INDEX], report, source_line)
+    if date is None:
         return assocparser.ParseResult(source_line, [], True, report=report)
-    date = association.Date(year=date_str[0:4], month=date_str[5:7], day=date_str[8:10], time=date_str[10:0])
 
     conjunctions = []
     # The elements of the extension units are Curie(Curie)

--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -424,6 +424,13 @@ def from_2_0(gpad_line: List[str], report=None, group="unknown", dataset="unknow
             report.error(source_line, Report.INVALID_SYMBOL, gpad_line[7], "Problem parsing Interacting Taxon", taxon=taxon, rule=1)
             return assocparser.ParseResult(source_line, [], True, report=report)
 
+    date_str = gpad_line[DATE_INDEX]
+    if date_str is None or date_str == "":
+        report.warning(source_line, Report.INVALID_DATE, date_str, "GORULE:0000001: empty",
+                       taxon=taxon, rule=1)
+        return assocparser.ParseResult(source_line, [], True, report=report)
+    date = association.Date(year=date_str[0:4], month=date_str[5:7], day=date_str[8:10], time=date_str[10:0])
+
     conjunctions = []
     # The elements of the extension units are Curie(Curie)
     if gpad_line[10]:
@@ -450,7 +457,7 @@ def from_2_0(gpad_line: List[str], report=None, group="unknown", dataset="unknow
         subject_extensions=[],
         object_extensions=conjunctions,
         provided_by=gpad_line[9],
-        date=gpad_line[8],
+        date=date,
         properties={ prop[0]: prop[1] for prop in properties_list if prop })
 
     return assocparser.ParseResult(source_line, [a], False, report=report)

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -385,14 +385,9 @@ class GoRule29(GoRule):
 
         time_compare_delta_short = self.one_year
         time_compare_delta_long = self.two_years
-        if "-" in date:
-            # Accommodating YYYY-MM-DD format
-            year, month, day = date[0:4], date[5:7], date[8:10]
-        else:
-            year, month, day = date[0:4], date[4:6], date[6:8]
-        time_diff = now - datetime.datetime(int(year),
-                                            int(month),
-                                            int(day),
+        time_diff = now - datetime.datetime(int(date.year),
+                                            int(date.month),
+                                            int(date.day),
                                             0, 0, 0, 0)
 
         iea = "ECO:0000501"

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -385,9 +385,14 @@ class GoRule29(GoRule):
 
         time_compare_delta_short = self.one_year
         time_compare_delta_long = self.two_years
-        time_diff = now - datetime.datetime(int(date[0:4]),
-                                            int(date[4:6]),
-                                            int(date[6:8]),
+        if "-" in date:
+            # Accommodating YYYY-MM-DD format
+            year, month, day = date[0:4], date[5:7], date[8:10]
+        else:
+            year, month, day = date[0:4], date[4:6], date[6:8]
+        time_diff = now - datetime.datetime(int(year),
+                                            int(month),
+                                            int(day),
                                             0, 0, 0, 0)
 
         iea = "ECO:0000501"

--- a/ontobio/model/association.py
+++ b/ontobio/model/association.py
@@ -23,7 +23,11 @@ logger = logging.getLogger(__name__)
 
 Aspect = typing.NewType("Aspect", str)
 Provider = typing.NewType("Provider", str)
-Date = typing.NewType("Date", str)
+Date = collections.namedtuple("Date", ["year", "month", "day", "time"])
+
+
+def ymd_str(date: Date, separator: str) -> str:
+    return "{year}{sep}{month}{sep}{day}".format(year=date.year, sep=separator, month=date.month, day=date.day)
 
 @dataclass
 class Error:
@@ -275,7 +279,7 @@ class GoAssociation:
             "|".join(self.subject.synonyms),
             self.subject.type,
             taxon,
-            self.date,
+            ymd_str(self.date, ""),
             self.provided_by,
             ConjunctiveSet.list_to_str(self.object_extensions,
                 conjunct_to_str=lambda conj: conj.display(use_rel_label=True)),
@@ -311,7 +315,7 @@ class GoAssociation:
             "|".join(self.subject.synonyms),
             self.subject.type,
             taxon,
-            self.date,
+            ymd_str(self.date, ""),
             self.provided_by,
             ConjunctiveSet.list_to_str(self.object_extensions),
             gp_isoforms
@@ -343,7 +347,7 @@ class GoAssociation:
             str(self.evidence.type),
             ConjunctiveSet.list_to_str(self.evidence.with_support_from),
             str(self.interacting_taxon) if self.interacting_taxon else "",
-            self.date,
+            ymd_str(self.date, ""),
             self.provided_by,
             ConjunctiveSet.list_to_str(self.object_extensions,
                 conjunct_to_str=lambda conj: conj.display(use_rel_label=True)),
@@ -362,7 +366,7 @@ class GoAssociation:
             str(self.evidence.type),
             ConjunctiveSet.list_to_str(self.evidence.with_support_from),
             str(self.interacting_taxon) if self.interacting_taxon else "",
-            self.date,
+            ymd_str(self.date, "-"),
             self.provided_by,
             ConjunctiveSet.list_to_str(self.object_extensions,
                 conjunct_to_str=lambda conj: conj.display()),
@@ -423,7 +427,7 @@ class GoAssociation:
             "interacting_taxon": self.interacting_taxon,
             "evidence": evidence,
             "provided_by": self.provided_by,
-            "date": self.date,
+            "date": ymd_str(self.date, ""),
             "subject_extensions": subject_extensions,
             "object_extensions": object_extensions
         }

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setuptools.setup(
         'yamldown',
         'dataclasses',
         'diskcache>=4.0.0',
-        'bidict==0.19.0'
+        'bidict==0.19.0',
+        'python-dateutil'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/tests/test_assoc_writer.py
+++ b/tests/test_assoc_writer.py
@@ -1,6 +1,6 @@
 from ontobio.io import assocwriter
 from ontobio.io import gafparser, gpadparser
-from ontobio.model.association import GoAssociation, Curie, Subject, Term, ConjunctiveSet, Evidence, ExtensionUnit
+from ontobio.model.association import GoAssociation, Curie, Subject, Term, ConjunctiveSet, Evidence, ExtensionUnit, Date
 import json
 import io
 
@@ -33,7 +33,7 @@ def test_gaf_writer():
             )]
         ),
         provided_by="PomBase",
-        date="20150305",
+        date=Date(year="2015", month="03", day="05", time=""),
         subject_extensions=[
             ExtensionUnit(
                 relation=Curie("rdfs", "subClassOf"),
@@ -207,7 +207,7 @@ def test_gaf_to_gpad2():
 
     lines = out.getvalue().split("\n")
     assert lines[0] == "!gpa-version: 2.0"
-    assert lines[1] == "PomBase:SPAC25B8.17\t\tBFO:0000050\tGO:0000006\tGO_REF:0000024\tECO:0000266\tSGD:S000001583\tNCBITaxon:888\t20150305\tPomBase\tBFO:0000050(X:1)\t"
+    assert lines[1] == "PomBase:SPAC25B8.17\t\tBFO:0000050\tGO:0000006\tGO_REF:0000024\tECO:0000266\tSGD:S000001583\tNCBITaxon:888\t2015-03-05\tPomBase\tBFO:0000050(X:1)\t"
 
     line = "PomBase\tSPAC25B8.17\typf1\tNOT\tGO:0000006\tGO_REF:0000024\tISO\tSGD:S000001583\tC\tintramembrane aspartyl protease of the perinuclear ER membrane Ypf1 (predicted)\tppp81\tprotein\ttaxon:999|taxon:888\t20150305\tPomBase\tpart_of(X:1)\tUniProtKB:P12345"
     parser = gafparser.GafParser()
@@ -219,4 +219,4 @@ def test_gaf_to_gpad2():
 
     lines = out.getvalue().split("\n")
     assert lines[0] == "!gpa-version: 2.0"
-    assert lines[1] == "PomBase:SPAC25B8.17\tNOT\tBFO:0000050\tGO:0000006\tGO_REF:0000024\tECO:0000266\tSGD:S000001583\tNCBITaxon:888\t20150305\tPomBase\tBFO:0000050(X:1)\t"
+    assert lines[1] == "PomBase:SPAC25B8.17\tNOT\tBFO:0000050\tGO:0000006\tGO_REF:0000024\tECO:0000266\tSGD:S000001583\tNCBITaxon:888\t2015-03-05\tPomBase\tBFO:0000050(X:1)\t"

--- a/tests/test_gafparser.py
+++ b/tests/test_gafparser.py
@@ -100,7 +100,7 @@ def parse_with(f, p):
 
     if is_gaf:
         assert r1.subject.label == 'ypf1'
-        assert r1.date == '20150305'
+        assert association.ymd_str(r1.date, "") == '20150305'
 
     for r in results:
         #print(str(r))

--- a/tests/test_goassociation_model.py
+++ b/tests/test_goassociation_model.py
@@ -68,3 +68,8 @@ def test_conjunctive_set_list_to_str():
             association.ConjunctiveSet(["GO:987"])
         ])
     assert c == "MGI:12345,DOI:333|GO:987"
+
+def test_date():
+    date_str = "20210105"
+    date = association.Date(date_str[0:4], date_str[4:6], date_str[6:8], "")
+    assert association.ymd_str(date, "-") == "2021-01-05"

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -317,14 +317,14 @@ def test_go_rule29():
     ## Pass if only a half year old.
     now = datetime.datetime.now()
     six_months_ago = now - datetime.timedelta(days=180)
-    assoc.date = six_months_ago.strftime("%Y%m%d")
+    assoc.date = association.Date(six_months_ago.year, six_months_ago.month, six_months_ago.day, "")
     assoc.evidence.type = Curie.from_str("ECO:0000501")
     test_result = qc.GoRule29().test(assoc, assocparser.AssocParserConfig())
     assert test_result.result_type == qc.ResultType.PASS
 
     ## Warning if a year and a half year old.
     eighteen_months_ago = now - datetime.timedelta(days=(30*18))
-    assoc.date = eighteen_months_ago.strftime("%Y%m%d")
+    assoc.date = association.Date(eighteen_months_ago.year, eighteen_months_ago.month, eighteen_months_ago.day, "")
     test_result = qc.GoRule29().test(assoc, assocparser.AssocParserConfig())
     assert test_result.result_type == qc.ResultType.WARNING
 

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -328,8 +328,11 @@ def test_go_rule29():
     test_result = qc.GoRule29().test(assoc, assocparser.AssocParserConfig())
     assert test_result.result_type == qc.ResultType.WARNING
 
-    ## Confirm the test can parse a YYYY-MM-DD date format from GPAD
-    assoc = make_annotation(evidence="ECO:0000501", date="1990-11-11", qualifier="part_of", from_gaf=False).associations[0]
+    ## Confirm the test can parse a YYYY-MM-DD date format from GPAD 2.0
+    gpad_2_0_vals = assoc.to_gpad_2_0_tsv()  # Cheat to shortcut DB and DB_Object_ID concatenation
+    gpad_2_0_vals[5] = "ECO:0000501"
+    gpad_2_0_vals[8] = "1990-11-11"
+    assoc = gpadparser.to_association(gpad_2_0_vals, version="2.0").associations[0]
     test_result = qc.GoRule29().test(assoc, assocparser.AssocParserConfig())
     assert test_result.result_type == qc.ResultType.ERROR
 

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -328,6 +328,11 @@ def test_go_rule29():
     test_result = qc.GoRule29().test(assoc, assocparser.AssocParserConfig())
     assert test_result.result_type == qc.ResultType.WARNING
 
+    ## Confirm the test can parse a YYYY-MM-DD date format from GPAD
+    assoc = make_annotation(evidence="ECO:0000501", date="1990-11-11", qualifier="part_of", from_gaf=False).associations[0]
+    test_result = qc.GoRule29().test(assoc, assocparser.AssocParserConfig())
+    assert test_result.result_type == qc.ResultType.ERROR
+
 def test_gorule30():
     assoc = make_annotation(references="GO_REF:0000033").associations[0]
 

--- a/tests/test_rdfgen.py
+++ b/tests/test_rdfgen.py
@@ -49,7 +49,7 @@ def test_rdfgen_includes_taxon_in_gp_class():
             )]
         ),
         provided_by=association.Provider("PomBase"),
-        date=association.Date("20150305"),
+        date=association.Date("2015", "03", "05", ""),
         subject_extensions=[
             association.ExtensionUnit(
                 relation=association.Curie("rdfs", "subClassOf"),


### PR DESCRIPTION
Uses the `date` variable, normalized with date format (YYYYMMDD), for internal GORULE tests rather than just passing through raw column value `gpad_line[8]`