### PR TITLE
gorule 61 implementation in ontobio

### DIFF
--- a/tests/test_gafparser.py
+++ b/tests/test_gafparser.py
@@ -92,7 +92,7 @@ def parse_with(f, p):
         p.config.ontology = None
 
     results = p.parse(open(f, "r"), skipheader=True)
-    # print(p.report.to_markdown())
+    print(p.report.to_markdown())
     r1 = results[0]
     # TODO: test datafile does not have ECOs yet!!
     assert ecomap.ecoclass_to_coderef(str(r1.evidence.type))[0] == 'ISO' or str(r1.evidence.type) == 'ECO:0000201'


### PR DESCRIPTION
This is the ontobio implementation for gorule-0000061.

The only thing tricky about this was handling identifying which tree of the ontology a GO term belonged to. In general I use the `OIO:hasOBONamespace` which *is* consistently defined for the ontology today.

But mostly in tests, there are some json ontologies that do not use this to identify the "namespace" of a term. I have chosen to think of a missing namespace as essentially "missing ontology". Presently, in the rules, the policy is to automatically pass any rule that does not have an attached ontology. This way rules that rely on the ontology can just be skipped if one isn't provided for whatever reason. The option to provide an ontology has been pretty historical in the code, although more current tooling *requires* an ontology in general. But some use cases w/out an ontology are still valid.

If we don't want to pass the rule if the `hasOBONamespace` is not defined, we would have to actually perform a subclass check which could represent some performance issues. If we need to go down that road, let us, but for now I've chosen to avoid it.