### PR TITLE
solr search query add support for filtering based on equivalent curie prefix, leaf nodes

### DIFF
--- a/ontobio/model/GolrResults.py
+++ b/ontobio/model/GolrResults.py
@@ -37,7 +37,6 @@ class SearchResults:
         self.numFound = numFound
         self.facet_counts = facet_counts
         self.highlighting = highlighting
-        return
 
 
 class AutocompleteResult:
@@ -61,7 +60,8 @@ class AutocompleteResult:
                  taxon: str,
                  taxon_label: str,
                  highlight: str,
-                 has_highlight: bool):
+                 has_highlight: bool,
+                 equivalent_ids: List[str]):
         self.id = id
         self.label = label
         self.match = match
@@ -70,4 +70,4 @@ class AutocompleteResult:
         self.taxon_label = taxon_label
         self.highlight = highlight
         self.has_highlight = has_highlight
-        return
+        self.equivalent_ids = equivalent_ids

--- a/tests/unit/resources/solr/expected/autocomplete-nocat.json
+++ b/tests/unit/resources/solr/expected/autocomplete-nocat.json
@@ -12,7 +12,8 @@
          ],
          "match":"food",
          "taxon":"",
-         "taxon_label":""
+         "taxon_label":"",
+         "equivalent_ids": []
       }
    ]
 }

--- a/tests/unit/resources/solr/expected/autocomplete.json
+++ b/tests/unit/resources/solr/expected/autocomplete.json
@@ -10,7 +10,8 @@
       "taxon": "NCBITaxon:559292",
       "match": "SHH3",
       "taxon_label": "Saccharomyces cerevisiae S288C",
-      "id": "SGD:S000004724"
+      "id": "SGD:S000004724",
+      "equivalent_ids": ["NCBIGene:855145"]
     },
     {
       "category": [
@@ -22,7 +23,8 @@
       "taxon": "NCBITaxon:559292",
       "match": "SHH4",
       "taxon_label": "Saccharomyces cerevisiae S288C",
-      "id": "SGD:S000004154"
+      "id": "SGD:S000004154",
+      "equivalent_ids": ["NCBIGene:850861"]
     },
     {
       "category": [
@@ -34,7 +36,8 @@
       "taxon": "NCBITaxon:9598",
       "match": "SHH",
       "taxon_label": "Pan troglodytes",
-      "id": "NCBIGene:743371"
+      "id": "NCBIGene:743371",
+      "equivalent_ids": ["ENSEMBL:ENSPTRG00000019912"]
     }
   ]
 }

--- a/tests/unit/test_golr_search_query.py
+++ b/tests/unit/test_golr_search_query.py
@@ -210,9 +210,32 @@ class TestGolrSearchParams():
             'MONDO'
         ]
         expected = [
-            'prefix:(-OMIA AND -Orphanet)',
+            '-prefix:(OMIA OR Orphanet)',
             'prefix:("DO" OR "OMIM" OR "MONDO")'
         ]
         self.manager.prefix = prefix_filter
+        params = self.manager.solr_params()
+        assert params['fq'] == expected
+
+    def test_prefix_filters_include_eq(self):
+        """
+        Test that prefix filters are converted
+        properly to solr params
+        """
+        prefix_filter = [
+            '-OMIA',
+            '-Orphanet',
+            'DO',
+            'OMIM',
+            'MONDO'
+        ]
+        expected = [
+            '(-prefix:OMIA OR -equivalent_curie:OMIA*)',
+            '(-prefix:Orphanet OR -equivalent_curie:Orphanet*)',
+            '((prefix:DO OR equivalent_curie:DO*) OR (prefix:OMIM OR '
+            'equivalent_curie:OMIM*) OR (prefix:MONDO OR equivalent_curie:MONDO*))'
+        ]
+        self.manager.prefix = prefix_filter
+        self.manager.include_eqs = True
         params = self.manager.solr_params()
         assert params['fq'] == expected


### PR DESCRIPTION
Adds support for filtering in/out a prefix in a equivalent curie as well as filtering for only leaf nodes. See https://github.com/biolink/biolink-api/issues/368