### PR TITLE
tweak to #550 - add colon to wildcard query

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -502,7 +502,7 @@ class GolrSearchQuery(GolrAbstractQuery):
             if negative_filter:
                 if self.include_eqs:
                     single_filts = [
-                        f"(-prefix:{prefix} OR -equivalent_curie:{prefix}*)"
+                        f'(-prefix:"{prefix}" OR -equivalent_curie:{prefix}\:*)'
                         for prefix in negative_filter
                     ]
                     for filt in single_filts:
@@ -510,13 +510,13 @@ class GolrSearchQuery(GolrAbstractQuery):
 
                 else:
                     neg_filter = '({})'.format(" OR ".join([filt for filt in negative_filter]))
-                    params['fq'].append('-prefix:{}'.format(neg_filter))
+                    params['fq'].append('-prefix:{}'.format(solr_quotify(negative_filter)))
 
             if positive_filter:
                 if self.include_eqs:
                     # fq=((prefix:HP OR equivalent_curie:HP) OR (prefix:MONDO OR equivalent_curie:MONDO))
                     single_filts = [
-                        f"(prefix:{prefix} OR equivalent_curie:{prefix}*)"
+                        f'(prefix:"{prefix}" OR equivalent_curie:{prefix}\:*)'
                         for prefix in positive_filter
                     ]
                     pos_filter = '({})'.format(" OR ".join([filt for filt in single_filts]))

--- a/tests/unit/test_golr_search_query.py
+++ b/tests/unit/test_golr_search_query.py
@@ -168,7 +168,7 @@ class TestGolrLayPersonSearch():
         expected object
         """
         expected_fh = os.path.join(os.path.dirname(__file__),
-                                  'resources/solr/expected/layperson.json')
+                                   'resources/solr/expected/layperson.json')
         processed_docs = json.load(open(expected_fh))
         output_docs = self.manager._process_layperson_results(self.pysolr_results)
 
@@ -210,7 +210,7 @@ class TestGolrSearchParams():
             'MONDO'
         ]
         expected = [
-            '-prefix:(OMIA OR Orphanet)',
+            '-prefix:("OMIA" OR "Orphanet")',
             'prefix:("DO" OR "OMIM" OR "MONDO")'
         ]
         self.manager.prefix = prefix_filter
@@ -230,10 +230,10 @@ class TestGolrSearchParams():
             'MONDO'
         ]
         expected = [
-            '(-prefix:OMIA OR -equivalent_curie:OMIA*)',
-            '(-prefix:Orphanet OR -equivalent_curie:Orphanet*)',
-            '((prefix:DO OR equivalent_curie:DO*) OR (prefix:OMIM OR '
-            'equivalent_curie:OMIM*) OR (prefix:MONDO OR equivalent_curie:MONDO*))'
+            '(-prefix:"OMIA" OR -equivalent_curie:OMIA\:*)',
+            '(-prefix:"Orphanet" OR -equivalent_curie:Orphanet\:*)',
+            '((prefix:"DO" OR equivalent_curie:DO\:*) OR (prefix:"OMIM" OR '
+            'equivalent_curie:OMIM\:*) OR (prefix:"MONDO" OR equivalent_curie:MONDO\:*))'
         ]
         self.manager.prefix = prefix_filter
         self.manager.include_eqs = True


### PR DESCRIPTION
Update to PR #550, adding a colon to the prefix filter to avoid cases like OMIM, OMIMPS