### PR TITLE
Updated to new RO term and relaxed error handling for missing ext rel

### DIFF
--- a/ontobio/rdfgen/gocamgen/gocamgen.py
+++ b/ontobio/rdfgen/gocamgen/gocamgen.py
@@ -601,7 +601,8 @@ class AssocGoCamModel(GoCamModel):
                         if ext_relation == "":
                             # AttributeError: 'NoneType' object has no attribute 'replace'
                             error_msg = "Relation '{}' not found in relations lookup. Skipping annotation translation.".format(str(rel.relation))
-                            raise errors.GocamgenException(error_msg)
+                            self.errors.append(errors.GocamgenException(error_msg))
+                            continue
                         ext_target = str(rel.term)
                         if ext_relation not in list(INPUT_RELATIONS.keys()) + list(HAS_REGULATION_TARGET_RELATIONS.keys()):
                             # No RO term yet. Try looking up in RO

--- a/ontobio/rdfgen/relations.py
+++ b/ontobio/rdfgen/relations.py
@@ -67,7 +67,7 @@ __relation_label_lookup = bidict({
     "acts upstream of positive effect": "http://purl.obolibrary.org/obo/RO_0004034",
     "located in": "http://purl.obolibrary.org/obo/RO_0001025",
     "is active in": "http://purl.obolibrary.org/obo/RO_0002432",
-    "exists during": "http://purl.obolibrary.org/obo/GOREL_0000032",
+    "exists during": "http://purl.obolibrary.org/obo/RO_0002491",
     "coincident with": "http://purl.obolibrary.org/obo/RO_0002008",
     "has regulation target": "http://purl.obolibrary.org/obo/GOREL_0000015",
     "not happens during": "http://purl.obolibrary.org/obo/GOREL_0000025",


### PR DESCRIPTION
For #572.

I also changed how missing extension relation errors are handled. This change now skips translating only the offending extension (e.g. `RO:0002491(GO:0098768)`) whereas the old code would skip translating the entire ~~annotation~~ _model for the gene_. The error is still being reported out.