### PR TITLE
Add missing chardet dependency for PyShEx. For #578

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ dataclasses
 diskcache>=4.0.0
 bidict>=0.20.0
 python-dateutil
+chardet


### PR DESCRIPTION
For #578.