### PR TITLE
Adding 'existence overlaps' RO relation

### DIFF
--- a/ontobio/rdfgen/relations.py
+++ b/ontobio/rdfgen/relations.py
@@ -68,6 +68,7 @@ __relation_label_lookup = bidict({
     "located in": "http://purl.obolibrary.org/obo/RO_0001025",
     "is active in": "http://purl.obolibrary.org/obo/RO_0002432",
     "exists during": "http://purl.obolibrary.org/obo/RO_0002491",
+    "existence overlaps": "http://purl.obolibrary.org/obo/RO_0002490",
     "coincident with": "http://purl.obolibrary.org/obo/RO_0002008",
     "has regulation target": "http://purl.obolibrary.org/obo/GOREL_0000015",
     "not happens during": "http://purl.obolibrary.org/obo/GOREL_0000025",


### PR DESCRIPTION
This is part of the work to transition from using 'exists during' as a GOREL relation to using appropriate temporal relations from RO.

Note that the current entry for 'exists during' refers to RO:0002491 whose label is actually 'existence starts and ends during'.  We should also clean this up at some point, as 'exists during' as a term label currently only exists in gorel.obo for GOREL:0000032.

@dustine32 @kltm - if we updated the entries for 'exists during' (i.e. change to GOREL id) to point to the GOREL id, would that break anything?  I would also then add the correct RO entry for 'existence starts and ends during'.