### PR TITLE
Fix bug in obograph_utils by replacing the usage of deprecated networkx methods

### DIFF
--- a/ontobio/obograph_util.py
+++ b/ontobio/obograph_util.py
@@ -183,7 +183,7 @@ def _get_association_nodes(digraph, sub, predicate, obj):
 
     # A fast way of checking if the triple is reified is seeing if the
     # predicate exists as a node
-    if predicate['pred'] in digraph.nodes(data=True):
+    if predicate['pred'] in digraph.nodes():
         # association_has_subject
         for neighbor, edges in digraph.pred[sub].items():
             for edge in edges.values():

--- a/ontobio/obograph_util.py
+++ b/ontobio/obograph_util.py
@@ -183,7 +183,7 @@ def _get_association_nodes(digraph, sub, predicate, obj):
 
     # A fast way of checking if the triple is reified is seeing if the
     # predicate exists as a node
-    if predicate['pred'] in digraph.node:
+    if predicate['pred'] in digraph.nodes(data=True):
         # association_has_subject
         for neighbor, edges in digraph.pred[sub].items():
             for edge in edges.values():

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests>=0.0
 pip>=9.0.1
 wheel>0.25.0
 pysolr>=3.6.0
-networkx==2.3
+networkx>=2.3
 matplotlib>=2.0.0
 SPARQLWrapper>=1.8.0
 pandas>=0.0


### PR DESCRIPTION
This PR,
- replaces the usage of a deprecated networkx method `graph.node` with `graph.nodes` in `obograph_util.py`.
- removes the pinning of networkx dependency

@matentzn Thanks for raising this issue again. Hopefully the next release should get rid of the fixed dependency