### PR TITLE
Unpin marshmallow

### DIFF
--- a/ontobio/config.py
+++ b/ontobio/config.py
@@ -1,7 +1,7 @@
 import logging
 import yaml
 import os
-from marshmallow import Schema, fields, pprint, post_load
+from marshmallow import Schema, fields, pprint, post_load, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ class OntologyConfigSchema(Schema):
     pre_load = fields.Bool(description="if true, load this ontology at startup")
 
     @post_load
-    def make_object(self, data):
+    def make_object(self, data, **kwargs):
         return OntologyConfig(**data)
 
 class EndpointSchema(Schema):
@@ -26,7 +26,7 @@ class EndpointSchema(Schema):
     timeout = fields.Int()
 
     @post_load
-    def make_object(self, data):
+    def make_object(self, data, **kwargs):
         return Endpoint(**data)
 
 class CategorySchema(Schema):
@@ -37,7 +37,7 @@ class CategorySchema(Schema):
     superclass = fields.Str()
 
     @post_load
-    def make_object(self, data):
+    def make_object(self, data, **kwargs):
         return Category(**data)
 
 class ConfigSchema(Schema):
@@ -61,7 +61,7 @@ class ConfigSchema(Schema):
     use_amigo_for = fields.List(fields.Str(description="category to use amigo for"))
 
     @post_load
-    def make_object(self, data):
+    def make_object(self, data, **kwargs):
         return Config(**data)
 
 class Endpoint():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-marshmallow>=3.0.0b11
+marshmallow>=3.0.0b11,<4.0
 jsobject>=0.0
 prefixcommons>=0.1.9
 requests>=0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-marshmallow==3.0.0b11
+marshmallow>=3.0.0b11
 jsobject>=0.0
 prefixcommons>=0.1.9
 requests>=0.0


### PR DESCRIPTION
This PR proposes to unpin `marshmallow` so that `ontobio` does not depend on a beta release dating from 2018.

That pinned dependency creates an unsolvable conflict in the [ODK](https://github.com/INCATools/ontology-development-kit), which uses both `ontobio` (requiring `marshmallow==3.0.0b11`) and `dataclasses-json` (requiring `marshmallow>=3.3.0`).

`marshmallow` is the last pinned dependency, so unpinning it would close #482.