### PR TITLE
Add Xenbase taxon map to owlsim 

### DIFF
--- a/ontobio/sim/api/owlsim2.py
+++ b/ontobio/sim/api/owlsim2.py
@@ -191,6 +191,9 @@ class OwlSim2Api(SimApi, InformationContentStore, FilteredSearchable):
         },
         '7955': {
             'gene': 'ZFIN'
+        },
+        '8353': {
+            'gene': 'Xenbase'
         }
     }
 


### PR DESCRIPTION
The latest monarch release includes Xenopus laevus and tropicalus grouped under the taxon 8353.  This will allow users to query owlsim and specifically target Xenopus genes (with XPO terms or any other phenotype in UPheno)