### PR TITLE
Updates Token field 'category' to 'categories'

### DIFF
--- a/ontobio/model/nlp.py
+++ b/ontobio/model/nlp.py
@@ -16,7 +16,7 @@ class Token:
     A token or entity extracted from a marked-up span
     """
     id: str
-    category: List[str] = field(default_factory=list)
+    categories: List[str] = field(default_factory=list)
     terms: List[str] = field(default_factory=list)
 
 


### PR DESCRIPTION
Addresses issue #615.

For the record, I don't know how long this has been broken or whether it's actually broken by all users of ontobio, or just in Monarch's SciGraph version. I'm hoping whoever reviews this PR might have some insight into whether it's a real problem.