### PR TITLE
Adds _taxon_map subkey to GolrSearchQuery result

### DIFF
--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -601,13 +601,14 @@ class GolrSearchQuery(GolrAbstractQuery):
 
         # inject the taxon map (aka a facet pivot) into the returned facets
         if self.taxon_map:
-            translated_facets['_taxon_map'] = {
-                taxon['value']: {
-                    taxon_label['value']: taxon_label['count']
-                    for taxon_label in taxon['pivot']
+            translated_facets['_taxon_map'] = [
+                {
+                    'id': taxon['value'],
+                    'label': taxon['pivot'][0]['value'],
+                    'count': taxon['pivot'][0]['count']
                 }
                 for taxon in results.facets['facet_pivot']['taxon,taxon_label']
-            }
+            ]
 
         highlighting = {
             doc['id']: asdict(self._process_highlight(results, doc))

--- a/ontobio/golr/golr_query.py
+++ b/ontobio/golr/golr_query.py
@@ -602,10 +602,11 @@ class GolrSearchQuery(GolrAbstractQuery):
         # inject the taxon map (aka a facet pivot) into the returned facets
         if self.taxon_map:
             translated_facets['_taxon_map'] = {
-                x['value']: {
-                    y['value']: y['count'] for y in x['pivot']
+                taxon['value']: {
+                    taxon_label['value']: taxon_label['count']
+                    for taxon_label in taxon['pivot']
                 }
-                for x in results.facets['facet_pivot']['taxon,taxon_label']
+                for taxon in results.facets['facet_pivot']['taxon,taxon_label']
             }
 
         highlighting = {


### PR DESCRIPTION
Currently, the biolink-api endpoint `/search/entity/{term}` returns just taxon labels in the `facet_counts. taxon_label` subkey, but other endpoints' filtering arguments require taxon IDs, not labels. Because of this, the Monarch frontend requires a map from taxon label to taxon ID, but ideally this data would come from the backend.

This PR adds an optional, but by default enabled facet to the results of `ontobio.golr.GolrSearchQuery`, specifically a subkey called `_taxon_map` with the following form:
```
"_taxon_map": [
  {
    "id": <taxon ID:str>,
    "label": <taxon label:str>,
    "count": <count:int>
  },
  ...
]
```

The extra facet can be disabled by passing `taxon_map=False` to `ontobio.golr.GolrSearchQuery`'s constructor.

Addresses https://github.com/biolink/biolink-api/issues/386.