### PR TITLE
Ignore GORULE:0000028 aspect check when parsing GPAD

### DIFF
--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -167,6 +167,10 @@ class GpadParser(assocparser.AssocParser):
 
         go_rule_results = qc.test_go_rules(assoc, self.config)
         for rule, result in go_rule_results.all_results.items():
+            if isinstance(rule, qc.GoRule28):
+                # ignore result of GORULE:0000028 since aspect check will always fail for GPAD and get repaired
+                continue
+
             if result.result_type == qc.ResultType.WARNING:
                 self.report.warning(line, assocparser.Report.VIOLATES_GO_RULE, "",
                                     msg="{id}: {message}".format(id=rule.id, message=result.message), rule=int(rule.id.split(":")[1]))

--- a/tests/unit/test_golr_search_query.py
+++ b/tests/unit/test_golr_search_query.py
@@ -11,7 +11,7 @@ class TestGolrSearchQuery():
 
     @classmethod
     def setup_class(self):
-        self.manager = GolrSearchQuery()
+        self.manager = GolrSearchQuery(taxon_map=False)
 
         # Mock the PySolr search function to
         # return our test docs


### PR DESCRIPTION
Fixes geneontology/pipeline#280.

Specifically, the aspect rule test ([GORULE:0000028](https://github.com/geneontology/go-site/tree/master/metadata/rules#aspect-can-only-be-one-of-c-p-f-and-should-be-repaired-using-the-go-term)) will still run for GPAD and repair the empty `GoAssociation.aspect` (this is how aspect is sourced when merging `noctua_{group}.gpad` into `{group}.gaf`) but the reports will no longer reflect failure.