### PR TITLE
Lock down evaluating allow_unmapped_eco defaults

### DIFF
--- a/bin/ontobio-parse-assocs.py
+++ b/bin/ontobio-parse-assocs.py
@@ -73,7 +73,7 @@ def main():
                         help='Increase output verbosity')
     parser.add_argument("--allow_paint", required=False, action="store_const", const=True,
                         help="Allow IBAs in parser")
-    parser.add_argument("--allow_unmapped_eco", required=False, action="store_const", const=True,
+    parser.add_argument("--allow_unmapped_eco", required=False, action="store_const", const=True, default=False,
                         help="When parsing GPAD, allow ECO class IDs that do not map to an ECO GAF code")
     parser.add_argument("-g", "--gpi", type=str, required=False, default=None,
                         help="GPI file")

--- a/ontobio/io/gpadparser.py
+++ b/ontobio/io/gpadparser.py
@@ -205,7 +205,7 @@ class GpadParser(assocparser.AssocParser):
         # ecomap is currently one-way only
         ecomap = self.config.ecomap
         if ecomap != None:
-            if self.config.allow_unmapped_eco is False and ecomap.ecoclass_to_coderef(str(assoc.evidence.type)) == (None,None):
+            if not self.config.allow_unmapped_eco and ecomap.ecoclass_to_coderef(str(assoc.evidence.type)) == (None,None):
                 self.report.error(line, assocparser.Report.UNKNOWN_EVIDENCE_CLASS, str(assoc.evidence.type),
                                   msg="Expecting a known ECO class ID that maps to an ECO GAF code", rule=1)
                 return assocparser.ParseResult(line, [], True)


### PR DESCRIPTION
For #620.

Quick fix to handle GO pipeline run context as explained here https://github.com/geneontology/go-site/issues/1847#issuecomment-1120020146