### PR TITLE
Restrict dataclasses pkg installation to < python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ plotly>=2.0.7
 pyyaml
 yamldown>=0.1.7
 click
-dataclasses
+dataclasses>=0.7;python_version<'3.7'
 diskcache>=4.0.0
 bidict>=0.20.0
 python-dateutil


### PR DESCRIPTION
Solves: 
- https://github.com/biolink/ontobio/issues/630

Using environment markers: https://peps.python.org/pep-0508/#environment-markers

Test that it works:

```
❯ docker run --rm -it python:3.7 sh -c 'pip install git+https://github.com/sransara/ontobio.git@fix-dataclasses-req && python'
[... docker & pip installer output removed for brevity ...]
Python 3.7.16 (default, Mar 14 2023, 03:47:39) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.path
['', '/usr/local/lib/python37.zip', '/usr/local/lib/python3.7', '/usr/local/lib/python3.7/lib-dynload', '/usr/local/lib/python3.7/site-packages']
>>> # Simulate environment where pip installed site-packages comes before stdlib packages
>>> sys.path.reverse()
>>> sys.path
['/usr/local/lib/python3.7/site-packages', '/usr/local/lib/python3.7/lib-dynload', '/usr/local/lib/python3.7', '/usr/local/lib/python37.zip', '']
>>>
>>> import ontobio
>>> 
```