### PR TITLE
Handle GPI label merge for geneontology/go-releases#50

### DIFF
--- a/ontobio/model/collections.py
+++ b/ontobio/model/collections.py
@@ -17,9 +17,21 @@ class BioEntities:
     def merge(self, other):
         """
         Merge another BioEntity set into this one. The `other` set will
-        override any collisions in this BioEntities
+        override any collisions in this BioEntities except for
+        any specific fields (e.g., label) handled below
         """
-        self.entities.update(other.entities)
+        # self.entities.update(other.entities)
+        for ent in other.entities:
+            if ent in self.entities:
+                # Handle specific field merges here
+                merged_ent = other.entities[ent]
+
+                # Carry forward existing label if other label is blank string or None
+                if not merged_ent.label:
+                    merged_ent.label = self.entities[ent].label
+                self.entities[ent] = merged_ent
+            else:
+                self.entities[ent] = other.entities[ent]
         return self
 
     def get(self, entity_id: Curie) -> Optional[Subject]:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -26,6 +26,15 @@ def test_bioentities_merge():
         Curie("BAR", "987"): Subject(Curie("BAR", "987"), "goodbye", "world", [], "protien", Curie("NCBITaxon", "999"))
     })
 
+    # Test that blank label does not overwrite existing label
+    p = collections.BioEntities({
+        Curie("BAR", "987"): Subject(Curie("BAR", "987"), "", "world", [], "protien", Curie("NCBITaxon", "999"))
+    })
+
+    assert o.merge(p) == collections.BioEntities({
+        Curie("BAR", "987"): Subject(Curie("BAR", "987"), "goodbye", "world", [], "protien", Curie("NCBITaxon", "999"))
+    })
+
 def test_bioentities_merge_clobber():
     e = collections.BioEntities({
         Curie("FOO", "123"): Subject(Curie("FOO", "123"), "hello", "world", [], "protien", Curie("NCBITaxon", "12345"))


### PR DESCRIPTION
For geneontology/go-releases#50.

This fleshes out the `collections.BioEntities.merge()` function to better handle labels when some are blank. The entity label should only be overwritten if the new label is non-blank.

In our actual use case here:
1. The GAF-derived GPI is parsed into `BioEntities` first.
2. The upstream, canonical MOD GPI is parsed and its own `BioEntities` object.
3. The upstream, canonical MOD GPI `BioEntities` are merged into the existing GAF-derived GPI `BioEntities` ensuring that, if the canonical GPI has a blank symbol, it does not clobber the existing non-blank symbol.