### PR TITLE
Reverting FAIL to OKAY since obsolete terms have no namespace

### DIFF
--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -904,7 +904,8 @@ class GoRule61(RepairRule):
         else:
             # If we reach here, we're in a weird case where a term is not in either
             # of the three main GO branches, or does not have a namespace defined.
-            return TestResult(repair_result(RepairState.FAILED, self.fail_mode), "{}: {}".format(self.message(repair_state), "GO term has no namespace"), annotation)
+            # If this is the case we should just pass along as if the ontology is missing
+            return TestResult(repair_result(RepairState.OKAY, self.fail_mode), "{}: {}".format(self.message(repair_state), "GO term has no namespace"), annotation)
 
         allowed_str = ", ".join([str(a) for a in allowed])
         return TestResult(repair_result(repair_state, self.fail_mode), "{}: {} should be one of {}".format(self.message(repair_state), relation, allowed_str), repaired_annotation)

--- a/tests/resources/goslim_generic.json
+++ b/tests/resources/goslim_generic.json
@@ -4940,6 +4940,63 @@
       "type" : "CLASS",
       "lbl" : "oxidoreductase activity"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_0006850",
+      "meta" : {
+        "definition" : {
+          "val" : "The process in which pyruvate is transported across a mitochondrial membrane, into or out of the mitochondrion.",
+          "xrefs" : [ "GOC:vw", "PMID:22628558" ]
+        },
+        "synonyms" : [ {
+          "pred" : "hasRelatedSynonym",
+          "val" : "pyruvate transmembrane transport in mitochondria",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "pyruvate transmembrane transport in mitochondrion",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "mitochondrial pyruvate transport",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "pyruvate membrane transport in mitochondria",
+          "xrefs" : [ ]
+        }, {
+          "pred" : "hasRelatedSynonym",
+          "val" : "pyruvate membrane transport in mitochondrion",
+          "xrefs" : [ ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#creation_date",
+          "val" : "2013-08-15T11:19:35Z"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "GO:1902361"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "biological_process"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#created_by",
+          "val" : "dph"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mitochondrial pyruvate transmembrane transport"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/GO_1902361",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/GO_0006850"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000231",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000227"
+        } ],
+        "deprecated" : true
+      },
+      "type" : "CLASS"
+    }, {
       "id" : "http://www.geneontology.org/formats/oboInOwl#hasScope",
       "type" : "PROPERTY",
       "lbl" : "has_scope"

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -721,6 +721,13 @@ def test_gorule61():
     assert test_result.result_type == qc.ResultType.WARNING
     assert test_result.result.relation == association.Curie(namespace="BFO", identity="0000050")
 
+    # obsoleted term - these won't have namespace in ontology so ensure they aren't failed by this rule 61
+    # instead should be handled by rule 20
+    assoc = make_annotation(goid="GO:1902361", qualifier="involved_in", evidence="ISS", from_gaf=True,
+                            version="2.2")
+    test_result = qc.GoRule61().test(assoc.associations[0], config)
+    assert test_result.result_type == qc.ResultType.PASS
+
 
 def test_all_rules():
     # pass


### PR DESCRIPTION
Change corresponds to geneontology/go-site#2002. Slight correction of initial PR https://github.com/biolink/ontobio/pull/646.

This fixes a bug introduced with https://github.com/biolink/ontobio/pull/646 that was failing all obsoleted terms in rule 61 because their ontology node did not have a `namespace` key:
https://github.com/biolink/ontobio/blob/6a9924a1295f896dfdf6df5796a9e1b6d1203df9/ontobio/io/qc.py#L907
An example obsoleted term is GO:1902361. The failed GO rule test example is here: https://github.com/geneontology/go-site/blob/master/metadata/rules/gorule-0000020.md

I added a test for this (within `ontobio`!!) under rule 61 and confirmed that the `go-site` [test suite](https://github.com/geneontology/go-site/blob/master/scripts/rule-example-validation.sh) (really just a wrapper around `ontobio`'s `validate.py rule` command) runs w/o error.