### PR TITLE
For #1523 check for unique GO ID

### DIFF
--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -352,15 +352,16 @@ class GoRule15(GoRule):
 class GoRule16(GoRule):
 
     def __init__(self):
-        super().__init__("GORULE:0000016", "All IC annotations should include a GO ID in the \"With/From\" column", FailMode.SOFT)
+        super().__init__("GORULE:0000016", "All IC annotations should include a GO ID in the \"With/From\" column that is also different from the entry in the \"GO ID\" column", FailMode.SOFT)
 
     def test(self, annotation: association.GoAssociation, config: assocparser.AssocParserConfig, group=None) -> TestResult:
         evidence = str(annotation.evidence.type)
         withfrom = annotation.evidence.with_support_from
+        goId = annotation.object.id
 
         okay = True
         if evidence == ic_eco:
-            only_go = [t for conjunctions in withfrom for t in conjunctions.elements if t.namespace == "GO"] # Filter terms that aren't GO terms
+            only_go = [t for conjunctions in withfrom for t in conjunctions.elements if (t.namespace == "GO" and goId is not None and t.identity != goId.identity)] # Filter terms that aren't GO terms and different from GO ID
             okay = len(only_go) >= 1
 
         return self._result(okay)

--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -357,11 +357,12 @@ class GoRule16(GoRule):
     def test(self, annotation: association.GoAssociation, config: assocparser.AssocParserConfig, group=None) -> TestResult:
         evidence = str(annotation.evidence.type)
         withfrom = annotation.evidence.with_support_from
-        goId = annotation.object.id
+
 
         okay = True
         if evidence == ic_eco:
-            only_go = [t for conjunctions in withfrom for t in conjunctions.elements if (t.namespace == "GO" and goId is not None and t.identity != goId.identity)] # Filter terms that aren't GO terms and different from GO ID
+            go_id = annotation.object.id
+            only_go = [t for conjunctions in withfrom for t in conjunctions.elements if (t.namespace == "GO" and go_id.namespace == "GO" and t.identity != go_id.identity)] # Filter terms that aren't GO terms and different from GO ID
             okay = len(only_go) >= 1
 
         return self._result(okay)

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -250,9 +250,15 @@ def test_go_rule_16():
     # GO term same as with/ID
     assoc = make_annotation(goid="GO:0044419", evidence="IC", withfrom="GO:0044419").associations[0]
 
+    #GO term same as withfrom
     test_result = qc.GoRule16().test(assoc, all_rules_config())
     assert test_result.result_type == qc.ResultType.WARNING
-        
+    
+    #GO term same as one of the withfrom terms
+    assoc = make_annotation(goid="GO:0044419", evidence="IC", withfrom="GO:0044419|GO:0035821").associations[0]
+    test_result = qc.GoRule16().test(assoc, all_rules_config())    
+    assert test_result.result_type == qc.ResultType.PASS
+            
     # No GO term w/ID
     assoc = make_annotation(evidence="IC", withfrom="BLAH:12345").associations[0]
     test_result = qc.GoRule16().test(assoc, all_rules_config())

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -247,9 +247,14 @@ def test_go_rules_15():
     assert test_result.result_type == qc.ResultType.WARNING    
 
 def test_go_rule_16():
+    # GO term same as with/ID
+    assoc = make_annotation(goid="GO:0044419", evidence="IC", withfrom="GO:0044419").associations[0]
+
+    test_result = qc.GoRule16().test(assoc, all_rules_config())
+    assert test_result.result_type == qc.ResultType.WARNING
+        
     # No GO term w/ID
     assoc = make_annotation(evidence="IC", withfrom="BLAH:12345").associations[0]
-
     test_result = qc.GoRule16().test(assoc, all_rules_config())
     assert test_result.result_type == qc.ResultType.WARNING
 


### PR DESCRIPTION
Updated to ensure that annotations with evidence code 'IC' have a GO Id entry in the 'with/from' field that is different from the GO Id for the annotation  