### PR TITLE
Add underscore to GO_REF:0000033

### DIFF
--- a/ontobio/io/qc.py
+++ b/ontobio/io/qc.py
@@ -517,7 +517,7 @@ class GoRule30(GoRule):
 class GoRule37(GoRule):
 
     def __init__(self):
-        super().__init__("GORULE:0000037", "IBA annotations should ONLY be assigned_by GO_Central and have GOREF:0000033 as a reference", FailMode.HARD)
+        super().__init__("GORULE:0000037", "IBA annotations should ONLY be assigned_by GO_Central and have GO_REF:0000033 as a reference", FailMode.HARD)
 
     def test(self, annotation: association.GoAssociation, config: assocparser.AssocParserConfig, group=None) -> TestResult:
         # If the evidence code is IBA, then (1) the assigned_by field must be GO_Central and (2) the reference field must be PMID:21873635
@@ -527,7 +527,7 @@ class GoRule37(GoRule):
 
         result = self._result(True) # By default we pass
         if evidence == iba_eco:
-            result = self._result(assigned_by == "GO_Central" and "GOREF:0000033" in references)
+            result = self._result(assigned_by == "GO_Central" and "GO_REF:0000033" in references)
 
         return result
 

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -462,7 +462,7 @@ def test_gorule30():
     assert test_result.result_type == qc.ResultType.PASS
 
 def test_gorule37():
-    assoc = make_annotation(evidence="IBA", references="GOREF:0000033", assigned_by="GO_Central").associations[0]
+    assoc = make_annotation(evidence="IBA", references="GO_REF:0000033", assigned_by="GO_Central").associations[0]
 
     test_result = qc.GoRule37().test(assoc, all_rules_config())
     assert test_result.result_type == qc.ResultType.PASS
@@ -476,7 +476,7 @@ def test_gorule37():
     test_result = qc.GoRule37().test(assoc, all_rules_config())
     assert test_result.result_type == qc.ResultType.ERROR
 
-    assoc.evidence.has_supporting_reference = [Curie.from_str("GOREF:0000033")]
+    assoc.evidence.has_supporting_reference = [Curie.from_str("GO_REF:0000033")]
     assoc.provided_by = "Pascale"  # IBA, but wrong assigned_by
     test_result = qc.GoRule37().test(assoc, all_rules_config())
     assert test_result.result_type == qc.ResultType.ERROR


### PR DESCRIPTION
For geneontology/go-site#2185. Updates GoRule test to look for correct `GO_REF:0000033` (with underscore) in IBA annotations.

This was meant to be coordinated with the generation of IBA GAF files after https://github.com/pantherdb/fullgo_paint_update/commit/c0587f299e98c1a909ca317b21c7556892cea033 but this should now be merged ASAP.